### PR TITLE
docs: add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,163 @@
+# election — Politiques.ch
+
+Site Django qui **projette en direct le résultat des votations fédérales suisses**
+le dimanche de scrutin : à partir des communes déjà dépouillées, il extrapole les
+communes manquantes et affiche le % de oui attendu, avec des cartes choroplèthes par
+objet.
+
+Titre public du site : « Projections de votations & autres analyses de politique
+helvétique » (`templates/base.html`).
+
+---
+
+## La méthode d'extrapolation (le cœur du projet)
+
+L'idée : les communes suisses ont des profils de vote stables. On les caractérise par
+leur historique, puis on prédit les communes non dépouillées à partir de celles qui
+le sont déjà.
+
+1. **Profil de commune par ACP** (`scripts/populate_pca.py`). On construit la matrice
+   commune × objet des % de oui sur **55 votations passées** (`Voix`), et on la
+   réduit à **6 composantes principales** (`sklearn`), stockées dans `PCAResult`.
+   Une commune qui n'a pas exactement 55 `Voix` est écartée de l'ACP.
+2. **Régression le jour J** (`scrutin/extrapolation.py`). Sur les communes déjà
+   comptabilisées, on ajuste par moindres carrés — **pondérés par le nombre de
+   bulletins rentrés** — un modèle linéaire `% oui ≈ Σ aᵢ·composanteᵢ + b`
+   (7 paramètres). On ajuste **le même modèle séparément pour la participation**.
+3. **Projection.** Pour chaque commune manquante, on applique les deux modèles, et on
+   estime son nombre de votants via `electeur_election_precedente`. On somme, on
+   ajoute au dépouillement confirmé, et on obtient le % de oui final projeté plus
+   l'`avance` (part du dépouillement déjà couverte).
+
+Garde-fou : sous **7 communes dépouillées**, `get_extrapolation` renvoie `0.5, 0.5, 0`
+plutôt qu'un ajustement sur trop peu de points.
+
+À noter : `scripts/run_extrapolation.py` **écrit les valeurs extrapolées dans les
+lignes `ScrutinEnCours`** des communes non dépouillées (tout en laissant
+`comptabilise=False`). C'est ce qui permet aux cartes d'afficher toute la Suisse —
+mais les cartes **ne distinguent donc pas visuellement réel et estimé**.
+
+---
+
+## Applications Django
+
+| App | Rôle |
+|---|---|
+| `scrutin` | Cœur métier : tous les modèles, la logique d'extrapolation, la vue d'accueil, le CSS et le logo. |
+| `pca` | Modèle `PCAResult` (6 coordonnées par commune) + vue nuage de points ACP colorée par langue. |
+| `carte` | `carte/API.py` : cartes choroplèthes Plotly sur le GeoJSON communal. |
+| `page_statique` | Pages éditables en base (Méthodes, Contact), servies par une route attrape-tout `path("<str>", …)`. |
+
+### Modèles (`scrutin/models.py`)
+`Canton` → `District` → `Commune` ; `SujetVote` (un objet de votation) ;
+**`Voix`** = résultat *historique définitif* commune × objet ; **`ScrutinEnCours`** =
+résultat *du jour*, avec `comptabilise` et `electeur_election_precedente` ;
+`Extrapolation` = un instantané horodaté de la projection (la vue affiche le dernier).
+
+La distinction `Voix` / `ScrutinEnCours` est structurante : `Voix` alimente l'ACP,
+`ScrutinEnCours` est réécrit toutes les quelques minutes le jour du scrutin.
+
+---
+
+## Pipeline de données
+
+Les scripts s'exécutent via **django-extensions** :
+`python manage.py runscript <nom>` (depuis la racine du repo).
+
+Amorçage, **dans cet ordre** (chaque étape dépend de la précédente) :
+
+```
+populate_commune          # cantons, districts, communes
+import_metadata_commune   # langue, degré d'urbanisation
+populate_voix             # 55 votations historiques  (⚠ supprime tous les SujetVote)
+set_nb_voix_commune       # Commune.nb_voix = électeurs de la dernière votation
+populate_pca              # ACP → PCAResult          (⚠ supprime tous les PCAResult)
+add_initial_scrutin_en_cours   # crée les lignes vides du jour J
+```
+
+Puis, en boucle le jour du scrutin :
+`update_scrutin_en_cours <json_courant> <json_precedent>` → `run_extrapolation`.
+
+`update_scrutin_en_cours` ne réimporte que les communes **nouvellement** dépouillées
+(différence entre deux instantanés JSON) — l'import complet était trop lent.
+
+`create_fake_json_input` fabrique un JSON de test en rejouant d'anciens résultats
+sur 5 % des communes tirées au hasard : c'est le moyen de tester sans attendre un
+vrai dimanche de votation.
+
+### Source des données
+JSON open data de la Confédération (`app-prod-static-voteinfo.s3…/ogd/`), format
+alémanique : `vorlagen`, `kantone`, `gemeinden`, `jaStimmenAbsolut`,
+`neinStimmenAbsolut`, `anzahlStimmberechtigte`, `eingelegteStimmzettel`.
+Les communes sont appariées par **numéro OFS** (`geoLevelnummer`).
+
+---
+
+## Déploiement (`download_data.sh`)
+
+Approche volontairement rustique : une boucle `while true` qui, à chaque tour,
+télécharge le JSON fédéral, met à jour la base, relance l'extrapolation, **puis
+aspire tout le site Django avec `wget --recursive` pour en faire un mirroir HTML
+statique** copié dans `/srv/html/` (servi par Apache).
+
+Conséquence importante : **la production ne fait pas tourner Django**. Le site en
+ligne est une photo statique régénérée en boucle — ce qui le rend insensible à la
+charge un soir de votation. Toute modification doit rester compatible avec cette
+aspiration (pas de contenu dépendant d'une requête utilisateur, pas de POST).
+
+Le script contient des valeurs codées en dur : `192.168.1.20:8000`, `/srv/html/`,
+`~/env/django/bin/activate`, et les noms `votation_septembre_2022_*`.
+
+---
+
+## Pièges connus
+
+**Configuration / démarrage**
+1. **Aucune migration pour `scrutin` ni `pca`** — ces apps n'ont même pas de dossier
+   `migrations/` (seul `page_statique/migrations/0001_initial.py` est versionné).
+   Un clone frais ne peut pas construire sa base : il faut `makemigrations scrutin pca`
+   d'abord. Le schéma n'est donc pas sous contrôle de version.
+2. `settings.py` lit la clé secrète dans **`/etc/secret_key.txt`** et **plante à
+   l'import** si le fichier est absent. Il charge aussi `../.env` (hors du repo) et
+   **exige** que la variable `debug` y vaille exactement `"True"` ou `"False"`.
+3. **PostgreSQL requis** (base `votation`, `db_user` / `db_password` depuis `.env`).
+4. Ni `requirements.txt`, ni `.gitignore`, ni environnement figé. Dépendances
+   implicites : `django` (≈3.1), `django-extensions`, `python-dotenv`,
+   `psycopg2`, `pandas`, `numpy`, `scipy`, `scikit-learn`, `plotly`, `geojson`.
+5. **Deux racines de données différentes.** Les scripts lisent `../data/…` (hors du
+   repo : `donnee_federale_v3.txt`, `communes/`, `votation_septembre_2022_*.json` —
+   **rien de tout ça n'est versionné**), alors que `carte/API.py` lit `data/…`
+   (dans le repo). Ne pas les confondre.
+6. `data/switzerland2.geojson` (6 Mo) n'est **référencé nulle part** ; seul
+   `K4voge_20220501_gf.geojson` sert, apparié sur `properties.vogeName`.
+
+**Valeurs codées en dur**
+7. `scrutin/views.py` génère les cartes des sujets **6, 7 et 8** en dur, et
+   `carte/views.py` du sujet **6** — spécifique à la votation de septembre 2022.
+8. Le `55` de `ScrutinAPI` (nombre de votations historiques attendu) est en dur à
+   deux endroits ; il doit être mis à jour à chaque ajout de votation, sinon toutes
+   les communes sont silencieusement écartées de l'ACP.
+9. `update_scrutin_en_cours.get_new_commune` boucle sur `range(2)` : il ne compare
+   que les **deux premiers** objets de votation.
+
+**Bugs latents repérés à la lecture** (non corrigés)
+10. `scrutin/views.py` : le cache pickle ouvre `cache.pickle` en **`'ab'` (append)**
+    à chaque requête — le fichier grossit sans fin et `pickle.load` ne relit que le
+    premier objet, donc le cache est figé dès la première écriture. `use_cache` est
+    de toute façon à `False` en dur.
+11. `Commune.get_last_nb_electeur_slow` fait `list(voix).sort(…)` sur une liste
+    jetable : le tri n'a **aucun effet**, et `voix[0]` renvoie un ordre arbitraire.
+12. `add_initial_scrutin_en_cours` / `update_scrutin_en_cours` : le `except:` autour
+    de `get_unique_commune_by_ofs` imprime l'erreur mais **ne fait pas `continue`** —
+    la boucle réutilise alors la `commune` de l'itération précédente.
+13. `ScrutinAPI.getVotationMatrixWithMetaInfo` utilise `voixs` **après** la boucle
+    (variable qui fuit) pour construire `sujets`, et appelle `Warning(…)` au lieu de
+    `warnings.warn(…)` — donc l'avertissement n'est jamais émis.
+
+## Conventions
+
+Domaine et modèles en **français** (`Commune`, `SujetVote`, `Voix`, `nombre_oui`,
+`requete`), messages de commit et quelques helpers en anglais. Garder le français
+pour tout ce qui touche au métier et à l'interface.
+
+Branches : `master`, plus `Frederic` et `Laurence` (travail à deux, fusionné par PR).


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` mapping the codebase for future AI-assisted work: the PCA-based extrapolation method, Django app layout, data pipeline run order, and the static-mirror deployment approach.
- Documents known pitfalls found while reading the code: missing migrations for `scrutin`/`pca`, hardcoded 2022-specific values, and a handful of latent bugs (append-mode pickle cache, a no-op `.sort()`, a missing `continue` after a bare `except`).

## Test plan
- [ ] Docs-only change, no behavior affected — review for accuracy