### PR TITLE
moteur: corriger les bugs latents de A4

### DIFF
--- a/scripts/add_initial_scrutin_en_cours.py
+++ b/scripts/add_initial_scrutin_en_cours.py
@@ -23,8 +23,9 @@ def import_votation(path_votation):
             for data_commune in data_canton['gemeinden']:
                 try:
                     commune = Commune.get_unique_commune_by_ofs(data_commune['geoLevelnummer'])
-                except:
+                except Exception:
                     print(f'Commune not found: {data_commune["geoLevelnummer"]}: {data_commune["geoLevelname"]}')
+                    continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue
                 scrutin = ScrutinEnCours(commune=commune,

--- a/scripts/populate_voix.py
+++ b/scripts/populate_voix.py
@@ -135,7 +135,7 @@ def add_foreigner(commune_voix, sujet_vote):
     communes = Commune.objects.filter(nom=name_commune)
     if len(communes) == 0:
         commune = Commune(nom=name_commune, numero_ofs=n_ofs_distric_etrange[name_district], district = district, canton=canton)
-    elif len(districts) == 1:
+    elif len(communes) == 1:
         commune = communes[0]
     else:
         raise Exception(f'There are more than one commune named {name_commune}')

--- a/scripts/update_scrutin_en_cours.py
+++ b/scripts/update_scrutin_en_cours.py
@@ -47,8 +47,9 @@ def import_votation(path_votation, commune_to_import):
                     continue
                 try:
                     commune = Commune.get_unique_commune_by_ofs(data_commune['geoLevelnummer'])
-                except:
+                except Exception:
                     print(f'Commune not found: {data_commune["geoLevelnummer"]}: {data_commune["geoLevelname"]}')
+                    continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue
                 result = data_commune['resultat']

--- a/scrutin/models.py
+++ b/scrutin/models.py
@@ -79,10 +79,9 @@ class Commune(models.Model):
         self.save()
 
     def get_last_nb_electeur_slow(self):
-        voix = Voix.objects.filter(commune = self)
-        list(voix).sort(key = lambda obj: obj.sujet_vote.date)
-        if len(voix) > 0 :
-            return voix[0].electeurs_inscrits
+        voix = Voix.objects.filter(commune = self).order_by('-sujet_vote__date').first()
+        if voix is not None:
+            return voix.electeurs_inscrits
         import warnings
         warnings.warn(f"Nb electeur not found for {self}")
         return 0
@@ -129,26 +128,30 @@ def get_percentage(voix):
 
 class ScrutinAPI:
     def getVotationMatrixWithMetaInfo():
+        import warnings
         valid_communes = []
         percentage_oui_all_commune = []
+        sujets = []
         for commune in Commune.objects.all():
             voix = Voix.objects.filter(commune=commune)
             if len(voix) != 55:
-                Warning(f"{commune} has only {len(voix)} and will be dropped from the PCA")
+                warnings.warn(f"{commune} has only {len(voix)} and will be dropped from the PCA")
                 continue
             valid_communes.append(commune)
             voixs = Voix.objects.filter(commune=commune).order_by('sujet_vote')
             percentage_oui = [get_percentage(voix) for voix in voixs]
             percentage_oui_all_commune.append(percentage_oui)
-        sujets = [voix.sujet_vote.nom for voix in voixs]
+            if not sujets:
+                sujets = [voix.sujet_vote.nom for voix in voixs]
         return (sujets, valid_communes), percentage_oui_all_commune
 
     def get_nb_inscrit():
+        import warnings
         nb_inscrit_all_commune = []
         for commune in Commune.objects.all():
             voix = Voix.objects.filter(commune=commune)
             if len(voix) != 55:
-                Warning(f"{commune} has only {len(voix)} and will be dropped from the result")
+                warnings.warn(f"{commune} has only {len(voix)} and will be dropped from the result")
                 continue
             voixs = Voix.objects.filter(commune=commune).order_by('sujet_vote')
             nb_inscrit_all_commune.append((commune.nom, [(voix.electeurs_inscrits, voix.sujet_vote.date) for voix in voixs]))


### PR DESCRIPTION
## Résumé
- `get_last_nb_electeur_slow` : `list(voix).sort(...)` sur une liste jetable → `.order_by('-sujet_vote__date').first()`.
- `ScrutinAPI` : `Warning(...)` → `warnings.warn(...)` (l'avertissement n'était jamais émis) ; `voixs` ne fuit plus hors boucle pour construire `sujets`.
- `add_initial_scrutin_en_cours.py` / `update_scrutin_en_cours.py` : le `except` autour de `get_unique_commune_by_ofs` fait maintenant `continue` (avant : réutilisation silencieuse de la commune de l'itération précédente).
- `populate_voix.add_foreigner` : `elif len(districts) == 1` → `elif len(communes) == 1` (copier-coller).

Liste fermée, issue de la lecture du code (voir CLAUDE.md "Pièges connus" et PLAN_MODERNISATION.md A4). Pas de refactor au-delà de ces bugs.

## Test plan
- [x] `python manage.py check`
- [x] `peupler_demo` sur base fraîche : 2141 communes, 55 votations, 2141 profils ACP — inchangé
- [x] Vérifié en shell : `get_last_nb_electeur_slow`, `ScrutinAPI.getVotationMatrixWithMetaInfo`, `ScrutinAPI.get_nb_inscrit`, `get_extrapolation` fonctionnent toujours
- [x] `ruff check` sur les fichiers touchés : pas de nouvelle erreur introduite (les 87 erreurs préexistantes du dépôt restent pour A5)