### PR TITLE
moteur: dé-harcoder septembre 2022 (B2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,18 +92,22 @@ import_metadata_commune   # langue, degré d'urbanisation
 populate_voix             # 55 votations historiques  (⚠ supprime tous les SujetVote)
 set_nb_voix_commune       # Commune.nb_voix = électeurs de la dernière votation
 populate_pca              # ACP → PCAResult          (⚠ supprime tous les PCAResult)
-add_initial_scrutin_en_cours   # crée les lignes vides du jour J
+add_initial_scrutin_en_cours --script-args <json_du_scrutin>   # lignes vides du jour J
 ```
 
 Puis, en boucle le jour du scrutin :
-`update_scrutin_en_cours <json_courant> <json_precedent>` → `run_extrapolation`.
+`update_scrutin_en_cours --script-args <json_courant> <json_precedent>` →
+`run_extrapolation`. C'est ce que fait `download_data.sh`, qui dérive URL et noms
+de fichiers de `DATE_SCRUTIN`.
 
 `update_scrutin_en_cours` ne réimporte que les communes **nouvellement** dépouillées
-(différence entre deux instantanés JSON) — l'import complet était trop lent.
+(différence entre deux instantanés JSON) — l'import complet était trop lent. Une
+commune n'est reprise que lorsqu'elle est rentrée pour **tous** les objets du
+scrutin.
 
-`create_fake_json_input` fabrique un JSON de test en rejouant d'anciens résultats
-sur 5 % des communes tirées au hasard : c'est le moyen de tester sans attendre un
-vrai dimanche de votation.
+`create_fake_json_input --script-args <json_du_scrutin> [<sortie>]` fabrique un JSON
+de test en rejouant d'anciens résultats sur 5 % des communes tirées au hasard :
+c'est le moyen de tester sans attendre un vrai dimanche de votation.
 
 ### Source des données
 JSON open data de la Confédération (`app-prod-static-voteinfo.s3…/ogd/`), format
@@ -138,23 +142,27 @@ Le script contient des valeurs codées en dur : `192.168.1.20:8000`, `/srv/html/
    **rien de tout ça n'est versionné**), alors que `carte/API.py` lit `data/…`
    (dans le repo). Ne pas les confondre.
 
-**Valeurs codées en dur**
-2. Le `55` de `ScrutinAPI` (nombre de votations historiques attendu) est en dur à
-   deux endroits ; il doit être mis à jour à chaque ajout de votation, sinon toutes
-   les communes sont silencieusement écartées de l'ACP.
-3. `update_scrutin_en_cours.get_new_commune` boucle sur `range(2)` : il ne compare
-   que les **deux premiers** objets de votation.
+**Valeurs codées en dur** — **corrigées** (jalon 3, tâche B2)
+2. Le `55` de `ScrutinAPI` était en dur à deux endroits → `nb_sujets_historiques()`,
+   déduit des `Voix`. Une commune à l'historique incomplet est toujours écartée de
+   l'ACP, mais avec un avertissement (le seuil de couverture est l'affaire de la
+   Partie 6).
+3. `update_scrutin_en_cours.get_new_commune` bouclait sur `range(2)` : il ignorait
+   les objets au-delà du deuxième et plantait sur un scrutin à objet unique.
+4. Les chemins `votation_septembre_2022_*` sont devenus des arguments
+   (`--script-args`), et `download_data.sh` dérive URL et fichiers de
+   `DATE_SCRUTIN`.
 
 **Bugs latents repérés à la lecture** — **corrigés** (jalon 2, tâche A4)
-4. `Commune.get_last_nb_electeur_slow` triait une liste jetable (tri sans effet)
+5. `Commune.get_last_nb_electeur_slow` triait une liste jetable (tri sans effet)
     → `order_by('-sujet_vote__date').first()`.
-5. `add_initial_scrutin_en_cours` / `update_scrutin_en_cours` /
+6. `add_initial_scrutin_en_cours` / `update_scrutin_en_cours` /
     `create_fake_json_input` : le `except` autour de `get_unique_commune_by_ofs`
     ne faisait pas `continue` — la boucle réutilisait la `commune` de
     l'itération précédente.
-6. `ScrutinAPI.getVotationMatrixWithMetaInfo` utilisait `voixs` après la boucle
+7. `ScrutinAPI.getVotationMatrixWithMetaInfo` utilisait `voixs` après la boucle
     (variable qui fuit) et appelait `Warning(…)` au lieu de `warnings.warn(…)`.
-7. `populate_voix.add_foreigner` testait `len(districts)` au lieu de
+8. `populate_voix.add_foreigner` testait `len(districts)` au lieu de
     `len(communes)` ; le message d'erreur des sujets en double référençait une
     variable inexistante (`commune.Canton`).
 

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -310,19 +310,22 @@ future sans toucher au code** — seulement la config et les données.
       (`python manage.py import_votations …`). Supprime la dépendance à
       django-extensions et donne argparse, `--help`, tests faciles.
 
-### B2. Dé-harcoder « septembre 2022 » **[M]**
-- [ ] Sujets affichés (cartes 6/7/8 en dur dans `scrutin/views.py`, 6 dans
+### B2. Dé-harcoder « septembre 2022 » **[M]** — *fait*
+- [x] Sujets affichés (cartes 6/7/8 en dur dans `scrutin/views.py`, 6 dans
       `carte/views.py`) → dériver dynamiquement : « les sujets de la dernière date
       de votation », déjà la logique de `home_view` pour l'histogramme.
-- [ ] Le « 55 » de `ScrutinAPI` (nombre de votations historiques) → calculé :
-      `SujetVote.objects.filter(historique).count()`, ou critère « la commune a un
-      résultat pour ≥ N % des sujets ». Marquer les sujets historiques vs jour J
-      (champ booléen ou convention par date).
-- [ ] `update_scrutin_en_cours.get_new_commune` : `range(2)` → itérer sur tous les
-      objets du scrutin (il peut y en avoir 1, 3, 4…).
-- [ ] Noms de fichiers `votation_septembre_2022_*` → chemin/date paramétrés.
-- [ ] URL du JSON fédéral paramétrée (elle change à chaque scrutin :
-      `sd-t-17-02-<date>-eidgAbstimmung.json`).
+      *(Déjà fait au jalon 1, avec `peupler_demo`.)*
+- [x] Le « 55 » de `ScrutinAPI` → `nb_sujets_historiques()`, déduit des `Voix`.
+      Pas de champ booléen ni de convention par date : un objet est historique
+      s'il a des `Voix`, ce qui est déjà la distinction structurante du modèle.
+      Le critère « ≥ N % des sujets » est laissé à la Partie 6 — il change les
+      entrées de l'ACP, ce n'est pas du dé-harcodage.
+- [x] `update_scrutin_en_cours.get_new_commune` : `range(2)` → itère sur tous les
+      objets du scrutin (il plantait aussi sur un scrutin à objet unique).
+- [x] Noms de fichiers `votation_septembre_2022_*` → arguments `--script-args` ;
+      `download_data.sh` dérive tout de `DATE_SCRUTIN`.
+- [x] URL du JSON fédéral paramétrée (elle change à chaque scrutin :
+      `sd-t-17-02-<date>-eidgAbstimmung.json`) — construite depuis `DATE_SCRUTIN`.
 
 ### B3. Qualité du pipeline **[M]**
 - [ ] `ScrutinAPI.getVotationMatrixWithMetaInfo` et `get_nb_inscrit` : boucle

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ request*.
 
 ### Répétition générale d'un soir de scrutin
 
-`python manage.py runscript create_fake_json_input` est l'outil officiel pour
-répéter une soirée **sans attendre un vrai dimanche de votation** : il rejoue
-d'anciens résultats sur 5 % des communes tirées au hasard et écrit un
-`json_fake.json` au format fédéral. On l'enchaîne ensuite avec le pipeline du
-jour J :
+`create_fake_json_input` est l'outil officiel pour répéter une soirée **sans
+attendre un vrai dimanche de votation** : il rejoue d'anciens résultats sur 5 %
+des communes tirées au hasard et écrit un JSON au format fédéral. On l'enchaîne
+ensuite avec le pipeline du jour J :
 
 ```bash
+python manage.py runscript create_fake_json_input --script-args <json_du_scrutin> json_fake.json
 python manage.py runscript update_scrutin_en_cours --script-args <json_precedent> json_fake.json
 python manage.py runscript run_extrapolation
 ```

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,42 +1,58 @@
 #!/bin/bash
+# Boucle du jour de scrutin : télécharger le JSON fédéral, mettre à jour la
+# base, relancer l'extrapolation, puis régénérer le mirroir statique.
+#
+# Tout ce qui change d'un scrutin à l'autre est en haut, ou surchargeable par
+# l'environnement :
+#   DATE_SCRUTIN=20260927 ./download_data.sh
 
-#avant de lancer le scipt, s'assurer d'avoir un fichier de données vides en exécutant
-#wget https://app-prod-static-voteinfo.s3.eu-central-1.amazonaws.com/v1/ogd/sd-t-17-02-20220925-eidgAbstimmung.json -O data/votation_septembre_2022_0.json;
-# AVANT QU'IL N'Y AIT LA MOINDRE DONNEE DISPONIBLE
+set -u
 
+DATE_SCRUTIN="${DATE_SCRUTIN:?à définir, ex. DATE_SCRUTIN=20260927}"
+DOSSIER_DATA="${DOSSIER_DATA:-../data}"
+HOTE_DJANGO="${HOTE_DJANGO:-192.168.1.20:8000}"
+DOSSIER_HTML="${DOSSIER_HTML:-/srv/html/}"
+VENV="${VENV:-~/env/django/bin/activate}"
+CADENCE="${CADENCE:-0}"
 
-#lancer django pour pouvoir activer les scripts
-source ~/env/django/bin/activate
+URL_SCRUTIN="https://app-prod-static-voteinfo.s3.eu-central-1.amazonaws.com/v1/ogd/sd-t-17-02-${DATE_SCRUTIN}-eidgAbstimmung.json"
+PREFIXE="${DOSSIER_DATA}/votation_${DATE_SCRUTIN}"
 
-#lancer la boucle qui va mettre à jour le site, le jour des votations.
+# Avant de lancer le script, s'assurer d'avoir un instantané initial — celui
+# d'avant toute donnée disponible :
+#   wget "$URL_SCRUTIN" -O "${PREFIXE}_0.json"
+# puis, une fois la base peuplée :
+#   python manage.py runscript add_initial_scrutin_en_cours --script-args "${PREFIXE}_0.json"
+
+# shellcheck source=/dev/null
+source "${VENV}"
+
 i=2
 while true;
 do
   #récupérer les données des dépouillements partiels (stockage incrémentiel)
 ((i=i+1));
-curl --output ../data/votation_septembre_2022_${i}.json.gz https://app-prod-static-voteinfo.s3.eu-central-1.amazonaws.com/v1/ogd/sd-t-17-02-20220925-eidgAbstimmung.json;
+curl --output "${PREFIXE}_${i}.json.gz" "${URL_SCRUTIN}";
 
-gunzip ../data/votation_septembre_2022_${i}.json.gz;
+gunzip "${PREFIXE}_${i}.json.gz";
 
   #mettre les données récupérées ci-dessus dans la base de donnée du site
 ((j=i-1))
-python manage.py runscript update_scrutin_en_cours --script-args ../data/votation_septembre_2022_${i}.json ../data/votation_septembre_2022_${j}.json
-
-#python manage.py runscript update_scrutin_en_cours --script-args ../data/votation_septembre_2022_1.json json_fake.json
+python manage.py runscript update_scrutin_en_cours --script-args "${PREFIXE}_${i}.json" "${PREFIXE}_${j}.json"
 
 echo "--------scrutin en cours mis à jour ---------"
 
   #fabriquer l'extrapolation sur la base des dépouillements partiels
 python manage.py runscript run_extrapolation
 echo " ** extrapolation terminée ** "
-#sleep 500;
 
   #copier le site dans le dossier où apache saura le trouver
-wget      --recursive      --no-clobber      --page-requisites      --html-extension      --convert-links      --restrict-file-names=windows                    192.168.1.20:8000  -P politiques
+wget      --recursive      --no-clobber      --page-requisites      --html-extension      --convert-links      --restrict-file-names=windows                    "${HOTE_DJANGO}"  -P politiques
 
 echo "!!!! site téléchargé !!!!";
 
-cp -r politiques/192.168.1.20+8000/* /srv/html/
+cp -r "politiques/${HOTE_DJANGO/:/+}"/* "${DOSSIER_HTML}"
 echo "** ** **"
 
+sleep "${CADENCE}";
 done

--- a/scripts/add_initial_scrutin_en_cours.py
+++ b/scripts/add_initial_scrutin_en_cours.py
@@ -34,6 +34,9 @@ def import_votation(path_votation):
                                          sujet_vote=sujet)
                 scrutin.save()
 
-def run():
+def run(*args):
+    if not args:
+        raise SystemExit("usage: runscript add_initial_scrutin_en_cours "
+                         "--script-args <json_du_scrutin>")
     ScrutinEnCours.objects.all().delete()
-    import_votation("../data/votation_septembre_2022_0.json")
+    import_votation(args[0])

--- a/scripts/create_fake_json_input.py
+++ b/scripts/create_fake_json_input.py
@@ -13,8 +13,12 @@ def get_result(commune, sujet):
     return None
 
 
-def run():
-    path_votation = "../data/votation_septembre_2022_1.json"
+def run(*args):
+    if not args:
+        raise SystemExit("usage: runscript create_fake_json_input "
+                         "--script-args <json_du_scrutin> [<json_de_sortie>]")
+    path_votation = args[0]
+    path_sortie = args[1] if len(args) > 1 else "json_fake.json"
     sujets = SujetVote.objects.order_by("date")
     with open(path_votation, 'r') as f:
         data = json.load(f)
@@ -40,5 +44,5 @@ def run():
                     resultat_json["anzahlStimmberechtigte"] = resultat_previous.electeurs_inscrits
                     resultat_json["eingelegteStimmzettel"] = resultat_previous.bulletins_rentres
 
-    with open("json_fake.json", 'w') as f:
+    with open(path_sortie, 'w') as f:
         json.dump(data, f)

--- a/scripts/update_scrutin_en_cours.py
+++ b/scripts/update_scrutin_en_cours.py
@@ -6,28 +6,35 @@ from scrutin.models import Commune, ScrutinEnCours, SujetVote
 def clean_date(date_str):
     return f'{date_str[0:4]}-{date_str[4:6]}-{date_str[6:8]}'
 
+def communes_depouillees(sujet_json):
+    return {
+        data_commune['geoLevelnummer']
+        for data_canton in sujet_json['kantone']
+        for data_commune in data_canton['gemeinden']
+        if data_commune['resultat']["jaStimmenAbsolut"] is not None
+    }
+
 def get_new_commune(path_previous, path_current):
+    """Communes nouvellement dépouillées pour *tous* les objets du scrutin.
+
+    On n'importe une commune que lorsqu'elle est rentrée pour chaque objet :
+    la boucle ne portait que sur les deux premiers, et un scrutin peut en
+    compter 1, 3 ou 4.
+    """
     with open(path_previous, 'r') as f:
         data_old = json.load(f)
     with open(path_current, 'r') as f:
         data_new = json.load(f)
-    commune_known_previous = []
-    all_new_commune = []
-    for index_sujet in range(2):
-        first_object = data_old['schweiz']['vorlagen'][index_sujet]
-        for data_canton in first_object['kantone']:
-            for data_commune in data_canton['gemeinden']:
-                if data_commune['resultat']["jaStimmenAbsolut"] is not None:
-                    commune_known_previous.append(data_commune['geoLevelnummer'])
-        commune_known_current = []
-        first_object = data_new['schweiz']['vorlagen'][index_sujet]
-        for data_canton in first_object['kantone']:
-            for data_commune in data_canton['gemeinden']:
-                if data_commune['resultat']["jaStimmenAbsolut"] is not None:
-                    commune_known_current.append(data_commune['geoLevelnummer'])
-        new_commune = set(commune_known_current) - set(commune_known_previous)
-        all_new_commune.append(new_commune)    
-    return all_new_commune[0].intersection(all_new_commune[1])
+    nouvelles = None
+    for sujet_ancien, sujet_nouveau in zip(data_old['schweiz']['vorlagen'],
+                                           data_new['schweiz']['vorlagen']):
+        nouvelles_du_sujet = (communes_depouillees(sujet_nouveau)
+                              - communes_depouillees(sujet_ancien))
+        if nouvelles is None:
+            nouvelles = nouvelles_du_sujet
+        else:
+            nouvelles &= nouvelles_du_sujet
+    return nouvelles if nouvelles is not None else set()
 def import_votation(path_votation, commune_to_import):
     with open(path_votation, 'r') as f:
         data = json.load(f)
@@ -66,7 +73,9 @@ def import_votation(path_votation, commune_to_import):
                 scrutin.save()
 
 def run(*args):
-    #commune_to_import = get_new_commune("../data/votation_septembre_2022_1.json", "json_fake.json")
+    if len(args) < 2:
+        raise SystemExit("usage: runscript update_scrutin_en_cours "
+                         "--script-args <json_precedent> <json_courant>")
     commune_to_import = get_new_commune(args[0], args[1])
     print(commune_to_import)
     import_votation(args[1], commune_to_import)

--- a/scrutin/management/commands/peupler_demo.py
+++ b/scrutin/management/commands/peupler_demo.py
@@ -36,9 +36,6 @@ from scrutin.models import (
 
 GRAINE = 20260825
 
-# Le « 55 » est encore codé en dur dans ScrutinAPI (tâche B2) : on génère
-# exactement ce nombre de votations historiques pour que le vrai populate_pca
-# tourne sans modification sur la base de démo.
 NB_VOTATIONS_HISTORIQUES = 55
 NB_OBJETS_JOUR_J = 3
 

--- a/scrutin/models.py
+++ b/scrutin/models.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.db import models
 
 
@@ -82,7 +84,6 @@ class Commune(models.Model):
         voix = Voix.objects.filter(commune = self).order_by('-sujet_vote__date').first()
         if voix is not None:
             return voix.electeurs_inscrits
-        import warnings
         warnings.warn(f"Nb electeur not found for {self}")
         return 0
 
@@ -126,16 +127,28 @@ class Extrapolation(models.Model):
 def get_percentage(voix):
     return voix.nombre_oui/(voix.nombre_oui + voix.nombre_non)
 
+
+def nb_sujets_historiques():
+    """Nombre d'objets de votation présents dans l'historique.
+
+    Remplace le « 55 » qui était codé en dur : il fallait le mettre à jour à
+    chaque votation ajoutée, faute de quoi toutes les communes étaient écartées
+    de l'ACP sans que rien ne le signale.
+    """
+    return Voix.objects.values('sujet_vote').distinct().count()
+
+
 class ScrutinAPI:
     def getVotationMatrixWithMetaInfo():
-        import warnings
+        attendu = nb_sujets_historiques()
         valid_communes = []
         percentage_oui_all_commune = []
         sujets = []
         for commune in Commune.objects.all():
             voix = Voix.objects.filter(commune=commune)
-            if len(voix) != 55:
-                warnings.warn(f"{commune} has only {len(voix)} and will be dropped from the PCA")
+            if len(voix) != attendu:
+                warnings.warn(f"{commune} has only {len(voix)} of {attendu} historical "
+                              "results and will be dropped from the PCA")
                 continue
             valid_communes.append(commune)
             voixs = Voix.objects.filter(commune=commune).order_by('sujet_vote')
@@ -146,12 +159,13 @@ class ScrutinAPI:
         return (sujets, valid_communes), percentage_oui_all_commune
 
     def get_nb_inscrit():
-        import warnings
+        attendu = nb_sujets_historiques()
         nb_inscrit_all_commune = []
         for commune in Commune.objects.all():
             voix = Voix.objects.filter(commune=commune)
-            if len(voix) != 55:
-                warnings.warn(f"{commune} has only {len(voix)} and will be dropped from the result")
+            if len(voix) != attendu:
+                warnings.warn(f"{commune} has only {len(voix)} of {attendu} historical "
+                              "results and will be dropped from the result")
                 continue
             voixs = Voix.objects.filter(commune=commune).order_by('sujet_vote')
             nb_inscrit_all_commune.append((commune.nom, [(voix.electeurs_inscrits, voix.sujet_vote.date) for voix in voixs]))

--- a/tests/test_import_scrutin.py
+++ b/tests/test_import_scrutin.py
@@ -1,0 +1,65 @@
+"""Détection des communes nouvellement dépouillées (`update_scrutin_en_cours`).
+
+La boucle ne portait que sur les deux premiers objets du scrutin : un scrutin
+à un seul objet plantait, un scrutin à trois objets en ignorait un.
+"""
+
+import json
+
+from scripts.update_scrutin_en_cours import get_new_commune
+
+
+def ecrire_scrutin(chemin, objets):
+    """Fabrique un JSON fédéral minimal.
+
+    ``objets`` est une liste (un élément par objet de votation) de dicts
+    ``{numero_ofs: dépouillée ou non}``.
+    """
+    data = {"schweiz": {"vorlagen": [
+        {
+            "vorlagenId": index + 1,
+            "kantone": [{"gemeinden": [
+                {
+                    "geoLevelnummer": ofs,
+                    "geoLevelname": f"Commune {ofs}",
+                    "resultat": {"jaStimmenAbsolut": 100 if depouillee else None},
+                }
+                for ofs, depouillee in communes.items()
+            ]}],
+        }
+        for index, communes in enumerate(objets)
+    ]}}
+    chemin.write_text(json.dumps(data))
+    return chemin
+
+
+def test_un_seul_objet_de_votation(tmp_path):
+    """Un scrutin à un seul objet levait `IndexError`."""
+    avant = ecrire_scrutin(tmp_path / "avant.json", [{1: False, 2: True}])
+    apres = ecrire_scrutin(tmp_path / "apres.json", [{1: True, 2: True}])
+
+    assert get_new_commune(str(avant), str(apres)) == {1}
+
+
+def test_trois_objets_exigent_le_depouillement_de_chacun(tmp_path):
+    """Le troisième objet était ignoré : une commune incomplète passait."""
+    avant = ecrire_scrutin(tmp_path / "avant.json", [
+        {1: False, 2: False},
+        {1: False, 2: False},
+        {1: False, 2: False},
+    ])
+    apres = ecrire_scrutin(tmp_path / "apres.json", [
+        {1: True, 2: True},
+        {1: True, 2: True},
+        # La commune 2 n'est pas rentrée pour le troisième objet.
+        {1: True, 2: False},
+    ])
+
+    assert get_new_commune(str(avant), str(apres)) == {1}
+
+
+def test_aucune_nouvelle_commune(tmp_path):
+    avant = ecrire_scrutin(tmp_path / "avant.json", [{1: True}, {1: True}])
+    apres = ecrire_scrutin(tmp_path / "apres.json", [{1: True}, {1: True}])
+
+    assert get_new_commune(str(avant), str(apres)) == set()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -28,6 +28,9 @@ def base_demo(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
         call_command("peupler_demo", verbosity=0)
         yield
+        # peupler_demo écrit hors du rollback de pytest-django : sans ce
+        # nettoyage, ses 2 141 communes fuient dans les modules suivants.
+        call_command("flush", "--no-input", verbosity=0)
 
 
 def sujets_du_jour():

--- a/tests/test_sujets_historiques.py
+++ b/tests/test_sujets_historiques.py
@@ -1,0 +1,89 @@
+"""Le nombre d'objets historiques doit se déduire des données, pas être en dur.
+
+Avec le « 55 » codé en dur, ajouter une votation à l'historique écartait
+*toutes* les communes de l'ACP — silencieusement, puisque l'avertissement
+n'était pas émis. C'est le piège le plus coûteux du dépôt : il ne se serait
+manifesté qu'un dimanche de scrutin.
+"""
+
+import datetime
+
+import pytest
+
+from scrutin.models import (
+    Canton,
+    Commune,
+    District,
+    ScrutinAPI,
+    SujetVote,
+    Voix,
+    nb_sujets_historiques,
+)
+
+
+def peupler(nb_sujets, nb_communes=3):
+    canton = Canton.objects.create(nom="Vaud", abreviation="VD")
+    district = District.objects.create(nom="Lavaux-Oron", numero_ofs=1, canton=canton)
+    communes = [
+        Commune.objects.create(nom=f"Commune {i}", numero_ofs=1000 + i,
+                               canton=canton, district=district)
+        for i in range(nb_communes)
+    ]
+    for i in range(nb_sujets):
+        ajouter_sujet(communes, i)
+    return communes
+
+
+def ajouter_sujet(communes, index):
+    sujet = SujetVote.objects.create(
+        nom=f"Objet {index}", sujet_id=index + 1,
+        date=datetime.date(2020, 1, 1) + datetime.timedelta(days=91 * index),
+    )
+    for rang, commune in enumerate(communes):
+        Voix.objects.create(
+            commune=commune, sujet_vote=sujet,
+            nombre_oui=400 + rang, nombre_non=600 - rang,
+            electeurs_inscrits=2000, bulletins_rentres=1000,
+        )
+    return sujet
+
+
+@pytest.mark.django_db
+def test_le_nombre_de_sujets_historiques_se_deduit_des_voix():
+    communes = peupler(nb_sujets=4)
+    assert nb_sujets_historiques() == 4
+
+    # Un objet du jour J n'a pas encore de Voix : il ne compte pas.
+    SujetVote.objects.create(nom="Jour J", sujet_id=99,
+                             date=datetime.date(2026, 9, 27))
+    assert nb_sujets_historiques() == 4
+
+    ajouter_sujet(communes, index=4)
+    assert nb_sujets_historiques() == 5
+
+
+@pytest.mark.django_db
+def test_ajouter_une_votation_n_ecarte_pas_les_communes_de_l_acp():
+    communes = peupler(nb_sujets=4)
+    (sujets, retenues), matrice = ScrutinAPI.getVotationMatrixWithMetaInfo()
+    assert len(retenues) == len(communes)
+    assert len(sujets) == 4
+
+    ajouter_sujet(communes, index=4)
+
+    (sujets, retenues), matrice = ScrutinAPI.getVotationMatrixWithMetaInfo()
+    assert len(retenues) == len(communes)
+    assert len(sujets) == 5
+    assert all(len(ligne) == 5 for ligne in matrice)
+
+
+@pytest.mark.django_db
+def test_une_commune_a_l_historique_incomplet_est_ecartee_avec_un_avertissement():
+    communes = peupler(nb_sujets=4)
+    Voix.objects.filter(commune=communes[0]).first().delete()
+
+    with pytest.warns(UserWarning, match="Commune 0"):
+        (_, retenues), _ = ScrutinAPI.getVotationMatrixWithMetaInfo()
+
+    assert communes[0] not in retenues
+    assert len(retenues) == len(communes) - 1


### PR DESCRIPTION
Le site était câblé sur la votation de septembre 2022. Après cette MR, couvrir un nouveau scrutin ne demande plus de toucher au code.

## Les trois valeurs en dur

**Le « 55 » de `ScrutinAPI`** → `nb_sujets_historiques()`, déduit des `Voix`. C'était le piège le plus coûteux du dépôt : à la première votation ajoutée à l'historique, `len(voix) != 55` écartait *toutes* les communes de l'ACP — et on ne l'aurait découvert qu'un dimanche de scrutin.

Pas de champ booléen ni de convention par date, comme le suggérait le plan : un objet est historique s'il a des `Voix`, ce qui est déjà la distinction structurante du modèle (`Voix` = historique, `ScrutinEnCours` = jour J). Aucune migration.

En revanche je **n'ai pas** touché au critère « exactement N sur N » pour retenir une commune. Passer à un seuil de couverture (≥ 90 %) change les entrées de l'ACP : c'est la Partie 6, pas du dé-harcodage.

**`get_new_commune` bouclait sur `range(2)`** → itère sur tous les objets. Au-delà de deux objets les suivants étaient ignorés (une commune passait sans être rentrée partout) ; avec un objet unique, `all_new_commune[1]` levait `IndexError`.

À signaler pour la relecture : j'avais d'abord cru que l'accumulation de `commune_known_previous` hors boucle était un second bug. Vérification faite, **elle est sans effet** — l'intersection finale absorbe la différence. Le code est plus clair maintenant, mais ce n'était pas un bug.

**Les chemins `votation_septembre_2022_*`** → `--script-args`. `download_data.sh` dérive URL et noms de fichiers de `DATE_SCRUTIN`, désormais **exigée** (`:?`) plutôt que défaillant sur 2022. Hôte Django, dossiers et cadence sont aussi surchargeables.

Le premier point de B2 (sujets 6/7/8 en dur dans les vues) était déjà fait au jalon 1.

## Un défaut de la MR précédente

La fixture `base_demo` que j'avais écrite en A5 fuyait : `peupler_demo` écrit hors du rollback de pytest-django, donc ses 2 141 communes et 55 votations polluaient les modules suivants. Invisible tant que ces tests étaient seuls — mes nouveaux tests ont échoué en suite complète mais passaient isolément. Corrigé par un `flush` en fin de fixture.

## Tests

`tests/test_import_scrutin.py` et `tests/test_sujets_historiques.py`, 6 tests. Chacun échoue sur le code d'avant :

| Test | Ce que faisait l'ancien code |
|---|---|
| un seul objet de votation | `IndexError` |
| trois objets, commune incomplète | l'acceptait (3ᵉ objet ignoré) |
| ajouter une votation historique | écartait les 3 communes sur 3 |

## Test plan
- [x] `pytest` → 17 tests
- [x] Suite relancée en forçant `test_pipeline` en premier → 17 tests (isolation vérifiée)
- [x] `ruff check .`, `manage.py check` → clean
- [x] `bash -n download_data.sh` ; refus correct sans `DATE_SCRUTIN` ; URL et destination `wget` vérifiées avec `DATE_SCRUTIN=20260927`
- [x] `grep` : plus aucune trace de `septembre_2022` ni `20220925` dans le dépôt