### PR TITLE
moteur: rendre les imports du jour J idempotents (B3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,12 @@ de fichiers de `DATE_SCRUTIN`.
 commune n'est reprise que lorsqu'elle est rentrée pour **tous** les objets du
 scrutin.
 
+Les deux imports du jour J sont **idempotents** : `add_initial_scrutin_en_cours`
+sème les lignes vides (`get_or_create`), `update_scrutin_en_cours` les remplit
+(`update_or_create`). Il n'y a donc jamais qu'une ligne `ResultatCommunalEnCours` par
+commune et par objet — l'invariant n'est pas garanti par la base, seulement par
+le code et `tests/test_import_idempotent.py`.
+
 `create_fake_json_input --script-args <json_du_scrutin> [<sortie>]` fabrique un JSON
 de test en rejouant d'anciens résultats sur 5 % des communes tirées au hasard :
 c'est le moyen de tester sans attendre un vrai dimanche de votation.

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -331,10 +331,16 @@ future sans toucher au code** — seulement la config et les données.
 - [ ] `ScrutinAPI.getVotationMatrixWithMetaInfo` et `get_nb_inscrit` : boucle
       1 requête/commune → une seule requête `select_related` + regroupement en
       mémoire (même optimisation déjà faite pour les cartes, commit d8d43b8).
-- [ ] Rendre les imports **idempotents** (relançables sans doublons) :
-      `update_or_create` plutôt que `save()` aveugle ; aujourd'hui relancer
-      `update_scrutin_en_cours` sur le même JSON crée des doublons de
-      `ResultatCommunalEnCours`.
+- [x] Rendre les imports **idempotents** (relançables sans doublons) :
+      `update_or_create` plutôt que `save()` aveugle. C'était pire que prévu —
+      le doublon n'attendait pas un rejeu : `add_initial_scrutin_en_cours` crée
+      la ligne vide, `update_scrutin_en_cours` en créait une **seconde** dès le
+      premier import, et l'extrapolation comptait la commune deux fois (une
+      réelle, une estimée).
+      *Reste ouvert* : aucune contrainte d'unicité en base sur
+      `(commune, sujet_vote)` — l'invariant n'est tenu que par le code et son
+      test. À ajouter si l'on accepte une migration qui échouera sur une base
+      contenant déjà des doublons.
 - [ ] Séparer clairement « résultat extrapolé » et « résultat observé » :
       `run_extrapolation` écrit actuellement les estimations **dans**
       `ResultatCommunalEnCours` (champs oui/non des communes non dépouillées). Ajouter des

--- a/scripts/add_initial_scrutin_en_cours.py
+++ b/scripts/add_initial_scrutin_en_cours.py
@@ -29,10 +29,11 @@ def import_votation(path_votation):
                     continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue
-                scrutin = ResultatCommunalEnCours(commune=commune,
-                                         electeur_election_precedente=commune.nb_voix,
-                                         sujet_vote=sujet)
-                scrutin.save()
+                ResultatCommunalEnCours.objects.get_or_create(
+                    commune=commune,
+                    sujet_vote=sujet,
+                    defaults={"electeur_election_precedente": commune.nb_voix},
+                )
 
 def run(*args):
     if not args:

--- a/scripts/update_scrutin_en_cours.py
+++ b/scripts/update_scrutin_en_cours.py
@@ -61,16 +61,18 @@ def import_votation(path_votation, commune_to_import):
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue
                 result = data_commune['resultat']
-                scrutin = ResultatCommunalEnCours(commune = commune,
-                                         electeur_election_precedente = commune.nb_voix,
-                                         sujet_vote = sujet,
-                                         nombre_oui = result["jaStimmenAbsolut"],
-                                         nombre_non = result["neinStimmenAbsolut"],
-                                         electeurs_inscrits=result["anzahlStimmberechtigte"],
-                                         bulletins_rentres=result["eingelegteStimmzettel"],
-                                         comptabilise = True
-                                         )
-                scrutin.save()
+                ResultatCommunalEnCours.objects.update_or_create(
+                    commune=commune,
+                    sujet_vote=sujet,
+                    defaults={
+                        "electeur_election_precedente": commune.nb_voix,
+                        "nombre_oui": result["jaStimmenAbsolut"],
+                        "nombre_non": result["neinStimmenAbsolut"],
+                        "electeurs_inscrits": result["anzahlStimmberechtigte"],
+                        "bulletins_rentres": result["eingelegteStimmzettel"],
+                        "comptabilise": True,
+                    },
+                )
 
 def run(*args):
     if len(args) < 2:

--- a/tests/test_import_idempotent.py
+++ b/tests/test_import_idempotent.py
@@ -1,0 +1,107 @@
+"""Les imports du jour J doivent être relançables sans créer de doublons.
+
+`add_initial_scrutin_en_cours` crée une ligne `ResultatCommunalEnCours` vide par commune
+et par objet ; `update_scrutin_en_cours` doit **remplir celle-là**, pas en
+ajouter une seconde. Sinon une commune dépouillée existe en double — une ligne
+comptabilisée et une ligne vide — et l'extrapolation la compte deux fois : une
+fois pour de vrai, une fois comme commune à estimer.
+"""
+
+import datetime
+import json
+
+import pytest
+
+from scripts.add_initial_scrutin_en_cours import import_votation as import_initial
+from scripts.update_scrutin_en_cours import import_votation as import_mise_a_jour
+from scrutin.models import Canton, Commune, District, ResultatCommunalEnCours
+
+OFS = [1001, 1002, 1003]
+
+
+@pytest.fixture
+def communes(db):
+    canton = Canton.objects.create(nom="Vaud", abreviation="VD")
+    district = District.objects.create(nom="Lavaux-Oron", numero_ofs=1, canton=canton)
+    return [
+        Commune.objects.create(nom=f"Commune {ofs}", numero_ofs=ofs,
+                               canton=canton, district=district, nb_voix=2000)
+        for ofs in OFS
+    ]
+
+
+def ecrire_scrutin(chemin, depouillees=()):
+    data = {
+        "abstimmtag": "20260927",
+        "schweiz": {"vorlagen": [{
+            "vorlagenId": 1,
+            "vorlagenTitel": [{"text": "Vorlage"}, {"text": "Objet de test"}],
+            "kantone": [{"gemeinden": [
+                {
+                    "geoLevelnummer": ofs,
+                    "geoLevelname": f"Commune {ofs}",
+                    "resultat": {
+                        "jaStimmenAbsolut": 600 if ofs in depouillees else None,
+                        "neinStimmenAbsolut": 400 if ofs in depouillees else None,
+                        "anzahlStimmberechtigte": 2000 if ofs in depouillees else None,
+                        "eingelegteStimmzettel": 1000 if ofs in depouillees else None,
+                    },
+                }
+                for ofs in OFS
+            ]}],
+        }]},
+    }
+    chemin.write_text(json.dumps(data))
+    return str(chemin)
+
+
+def test_la_mise_a_jour_remplit_la_ligne_existante(communes, tmp_path):
+    import_initial(ecrire_scrutin(tmp_path / "initial.json"))
+    assert ResultatCommunalEnCours.objects.count() == len(OFS)
+
+    import_mise_a_jour(ecrire_scrutin(tmp_path / "t1.json", depouillees=[1001]),
+                       commune_to_import={1001})
+
+    assert ResultatCommunalEnCours.objects.count() == len(OFS), (
+        "la commune dépouillée existe en double : une ligne comptabilisée et "
+        "une ligne vide, que l'extrapolation compterait toutes les deux"
+    )
+    ligne = ResultatCommunalEnCours.objects.get(commune__numero_ofs=1001)
+    assert ligne.comptabilise is True
+    assert (ligne.nombre_oui, ligne.nombre_non) == (600, 400)
+
+
+def test_rejouer_le_meme_json_ne_cree_pas_de_doublon(communes, tmp_path):
+    import_initial(ecrire_scrutin(tmp_path / "initial.json"))
+    courant = ecrire_scrutin(tmp_path / "t1.json", depouillees=[1001, 1002])
+
+    import_mise_a_jour(courant, commune_to_import={1001, 1002})
+    import_mise_a_jour(courant, commune_to_import={1001, 1002})
+
+    assert ResultatCommunalEnCours.objects.count() == len(OFS)
+    assert ResultatCommunalEnCours.objects.filter(comptabilise=True).count() == 2
+
+
+def test_l_import_initial_est_relancable(communes, tmp_path):
+    initial = ecrire_scrutin(tmp_path / "initial.json")
+
+    import_initial(initial)
+    import_initial(initial)
+
+    assert ResultatCommunalEnCours.objects.count() == len(OFS)
+
+
+def test_une_commune_absente_de_la_base_est_ignoree(communes, tmp_path):
+    """Le JSON fédéral contient des communes que la base ne connaît pas."""
+    Commune.objects.filter(numero_ofs=1003).delete()
+
+    import_initial(ecrire_scrutin(tmp_path / "initial.json"))
+
+    assert ResultatCommunalEnCours.objects.count() == len(OFS) - 1
+
+
+def test_la_date_du_sujet_vient_du_json(communes, tmp_path):
+    import_initial(ecrire_scrutin(tmp_path / "initial.json"))
+
+    ligne = ResultatCommunalEnCours.objects.first()
+    assert ligne.sujet_vote.date == datetime.date(2026, 9, 27)


### PR DESCRIPTION
Un bug de correction, pas de confort : il fausse les projections d'un vrai dimanche de scrutin.

## Le problème

`add_initial_scrutin_en_cours` crée une ligne `ScrutinEnCours` vide par commune et par objet. `update_scrutin_en_cours` **en créait une seconde** au lieu de remplir celle-là (`ScrutinEnCours(...)` + `save()`, jamais `update_or_create`).

Une commune dépouillée existait donc en double : une ligne `comptabilise=True` avec ses vrais résultats, et la ligne vide d'origine restée `comptabilise=False`. `get_extrapolation` itère sur toutes les lignes du sujet — il comptait donc la commune **deux fois** : une fois dans le dépouillement confirmé, une fois dans les communes à estimer.

Le plan ne prévoyait ce doublon qu'en cas de rejeu du même JSON. En réalité il apparaît **dès le premier import**, et se cumule à chaque tour de la boucle du jour J.

## La correction

- `update_scrutin_en_cours` → `update_or_create` sur `(commune, sujet_vote)`.
- `add_initial_scrutin_en_cours` → `get_or_create`. Volontairement pas `update_or_create` : cette étape sème les lignes vides, elle ne doit jamais écraser un résultat déjà rentré si on la relance en cours de soirée.

## Ce que je n'ai pas fait

**Aucune contrainte d'unicité en base** sur `(commune, sujet_vote)`. Ce serait la vraie garantie, mais la migration échouerait sur une base contenant déjà des doublons — ce qui est précisément le cas de toute base ayant tourné un soir de scrutin. L'invariant n'est donc tenu que par le code et son test. Noté comme point ouvert dans le plan : dis-moi si tu veux la contrainte, avec une migration de dédoublonnage.

Les deux autres points de B3 (N+1 dans `ScrutinAPI`, séparer réel/estimé) restent à faire. Le second demande une migration et sera consommé par la voie I pour les cartes réel/estimé — ça mérite sa propre MR.

## Tests

`tests/test_import_idempotent.py`, 5 tests. Trois échouent sur le code d'avant :

| Test | Avant |
|---|---|
| la mise à jour remplit la ligne existante | 4 lignes pour 3 communes |
| rejouer le même JSON | doublons cumulés |
| l'import initial est relançable | 6 lignes pour 3 communes |

Les deux autres (commune inconnue ignorée, date lue du JSON) documentent un comportement déjà correct, pour ne pas le casser en refactorant.

## Test plan
- [x] `pytest` → 22 tests
- [x] `ruff check .`, `manage.py check` → clean
- [x] Les 3 tests de régression vérifiés en échec sur le code d'avant