### PR TITLE
moteur: lire l'historique en une requête au lieu d'une par commune (B3)

### DIFF
--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -328,9 +328,14 @@ future sans toucher au code** — seulement la config et les données.
       `sd-t-17-02-<date>-eidgAbstimmung.json`) — construite depuis `DATE_SCRUTIN`.
 
 ### B3. Qualité du pipeline **[M]**
-- [ ] `ScrutinAPI.getVotationMatrixWithMetaInfo` et `get_nb_inscrit` : boucle
+- [x] `ScrutinAPI.getVotationMatrixWithMetaInfo` et `get_nb_inscrit` : boucle
       1 requête/commune → une seule requête `select_related` + regroupement en
       mémoire (même optimisation déjà faite pour les cartes, commit d8d43b8).
+      Sur la base de démo (2 141 communes × 55 objets) : 4 339 → 3 requêtes pour
+      la matrice ACP (1,9 s → 1,1 s), et 20,3 s → 1,3 s pour `get_nb_inscrit`,
+      qui interrogeait la base à *chaque* accès à `sujet_vote.date`.
+      *À noter* : `get_nb_inscrit` n'a aucun appelant dans le dépôt — à supprimer
+      si personne ne la réclame.
 - [x] Rendre les imports **idempotents** (relançables sans doublons) :
       `update_or_create` plutôt que `save()` aveugle. C'était pire que prévu —
       le doublon n'attendait pas un rejeu : `add_initial_scrutin_en_cours` crée

--- a/scrutin/models.py
+++ b/scrutin/models.py
@@ -138,20 +138,33 @@ def nb_sujets_historiques():
     return ResultatCommunalHistorique.objects.values('sujet_vote').distinct().count()
 
 
+def resultats_historiques_par_commune():
+    """Tout l'historique, groupé par commune, en une seule requête.
+
+    Chaque liste est ordonnée par objet de votation : c'est ce qui garantit que
+    les colonnes de la matrice ACP désignent le même objet d'une commune à
+    l'autre.
+    """
+    resultats = {}
+    for voix in ResultatCommunalHistorique.objects.select_related('sujet_vote').order_by('sujet_vote'):
+        resultats.setdefault(voix.commune_id, []).append(voix)
+    return resultats
+
+
 class ScrutinAPI:
     def getVotationMatrixWithMetaInfo():
         attendu = nb_sujets_historiques()
+        resultats = resultats_historiques_par_commune()
         valid_communes = []
         percentage_oui_all_commune = []
         sujets = []
         for commune in Commune.objects.all():
-            voix = ResultatCommunalHistorique.objects.filter(commune=commune)
-            if len(voix) != attendu:
-                warnings.warn(f"{commune} has only {len(voix)} of {attendu} historical "
+            voixs = resultats.get(commune.id, [])
+            if len(voixs) != attendu:
+                warnings.warn(f"{commune} has only {len(voixs)} of {attendu} historical "
                               "results and will be dropped from the PCA")
                 continue
             valid_communes.append(commune)
-            voixs = ResultatCommunalHistorique.objects.filter(commune=commune).order_by('sujet_vote')
             percentage_oui = [get_percentage(voix) for voix in voixs]
             percentage_oui_all_commune.append(percentage_oui)
             if not sujets:
@@ -160,14 +173,14 @@ class ScrutinAPI:
 
     def get_nb_inscrit():
         attendu = nb_sujets_historiques()
+        resultats = resultats_historiques_par_commune()
         nb_inscrit_all_commune = []
         for commune in Commune.objects.all():
-            voix = ResultatCommunalHistorique.objects.filter(commune=commune)
-            if len(voix) != attendu:
-                warnings.warn(f"{commune} has only {len(voix)} of {attendu} historical "
+            voixs = resultats.get(commune.id, [])
+            if len(voixs) != attendu:
+                warnings.warn(f"{commune} has only {len(voixs)} of {attendu} historical "
                               "results and will be dropped from the result")
                 continue
-            voixs = ResultatCommunalHistorique.objects.filter(commune=commune).order_by('sujet_vote')
             nb_inscrit_all_commune.append((commune.nom, [(voix.electeurs_inscrits, voix.sujet_vote.date) for voix in voixs]))
         return nb_inscrit_all_commune
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -83,6 +83,23 @@ def test_aucune_commune_n_est_ecartee_de_la_matrice_acp(base_demo):
 
 @pytest.mark.lent
 @pytest.mark.django_db
+def test_l_historique_se_lit_en_un_nombre_constant_de_requetes(
+        base_demo, django_assert_max_num_queries):
+    """La lecture faisait deux requêtes par commune, plus une par ``sujet_vote``.
+
+    Soit 4 339 requêtes pour la matrice ACP et 20 s pour ``get_nb_inscrit``.
+    Le seuil est large : ce qu'on veut attraper, c'est le retour d'une boucle
+    de requêtes, pas quelques requêtes de plus.
+    """
+    with django_assert_max_num_queries(10):
+        ScrutinAPI.getVotationMatrixWithMetaInfo()
+
+    with django_assert_max_num_queries(10):
+        ScrutinAPI.get_nb_inscrit()
+
+
+@pytest.mark.lent
+@pytest.mark.django_db
 def test_l_extrapolation_corrige_le_biais_du_depouillement_partiel(base_demo):
     """Le pipeline complet : ACP réelle, puis projection.
 


### PR DESCRIPTION
## Résumé
Premier point restant de **B3** : `ScrutinAPI.getVotationMatrixWithMetaInfo` et `get_nb_inscrit` faisaient deux requêtes par commune, et `get_nb_inscrit` une de plus à *chaque* accès à `sujet_vote.date` — soit de l'ordre de 120 000 requêtes pour 2 141 communes × 55 objets.

Nouveau helper `resultats_historiques_par_commune()` : un `select_related('sujet_vote')` + un regroupement par `commune_id`, réutilisé par les deux méthodes. L'ordre par objet de votation est conservé — c'est lui qui garantit que les colonnes de la matrice ACP désignent le même objet d'une commune à l'autre.

## Mesures (base `peupler_demo`, 2 141 communes × 55 objets)

| | avant | après |
|---|---|---|
| matrice ACP | 4 339 requêtes, 1,9 s | **3 requêtes, 1,1 s** |
| `get_nb_inscrit` | 20,3 s | **1,3 s** |

## À noter
`get_nb_inscrit` n'a **aucun appelant** dans le dépôt. Je l'ai optimisée quand même (le helper est partagé, ça coûte deux lignes) et le nouveau test est aujourd'hui son seul appelant. À supprimer si personne ne la réclame — dis-moi et je le fais dans une PR séparée.

## Test plan
- [x] Nouveau test `test_l_historique_se_lit_en_un_nombre_constant_de_requetes` (marqué `lent`), avec `django_assert_max_num_queries(10)`
- [x] Vérifié qu'il **échoue** sur l'ancienne implémentation (sinon il ne garde rien)
- [x] `pytest` (23 passed) — les tests existants couvrent déjà la forme et le contenu de la matrice, et `test_l_extrapolation_corrige_le_biais_du_depouillement_partiel` fait tourner la vraie ACP par-dessus
- [x] `ruff check .`