### PR TITLE
plan: comptabilise distingue déjà réel et estimé (B3)

### DIFF
--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -346,11 +346,12 @@ future sans toucher au code** — seulement la config et les données.
       `(commune, sujet_vote)` — l'invariant n'est tenu que par le code et son
       test. À ajouter si l'on accepte une migration qui échouera sur une base
       contenant déjà des doublons.
-- [ ] Séparer clairement « résultat extrapolé » et « résultat observé » :
-      `run_extrapolation` écrit actuellement les estimations **dans**
-      `ResultatCommunalEnCours` (champs oui/non des communes non dépouillées). Ajouter des
-      champs dédiés (`oui_estime`, …) ou une table `ExtrapolationCommune` — condition
-      préalable aux cartes réel/estimé de la phase D.
+- [x] Séparer « résultat extrapolé » et « résultat observé » : déjà porté par
+      `ResultatCommunalEnCours.comptabilise`, auquel `run_extrapolation` ne touche
+      pas. Ni champ dédié ni migration.
+- [ ] `ScrutinAPI.get_percentage_oui_all_commune` laisse tomber `comptabilise` :
+      le faire remonter jusqu'au contrat de vue, pour les cartes réel/estimé de
+      la phase D.
 - [ ] Journalisation (`logging`) au lieu de `print`.
 
 ### B4. Données historiques pérennes — **[I]** sources, **[M]** code


### PR DESCRIPTION
## Résumé
Modification **documentaire seulement** (`PLAN_MODERNISATION.md`). Tu avais raison : le booléen existait déjà.

`ResultatCommunalEnCours.comptabilise` ne vaut `True` que pour les communes réellement dépouillées — seuls `update_scrutin_en_cours.py:73` et `peupler_demo.py:292` le mettent à `True`, et `run_extrapolation.py` n'y touche jamais. Vérifié sur la base de démo :

```
(comptabilise=True, False)  avant=(1177, 964)  apres=(1177, 964)
ligne non dépouillée : nombre_oui 596 -> 718, comptabilise=False
```

Donc ni champ `oui_estime`, ni table `ExtrapolationCommune`, ni migration.

## Ce que ça change dans le plan
- L'item passe à `[x]`, en trois lignes.
- Un item pour ce qui reste : `get_percentage_oui_all_commune` laisse tomber le drapeau, il faut le faire remonter jusqu'au contrat de vue.

Suite à ta relecture : raisonnement sur `ExtrapolationCommune` retiré, puce « deux incohérences » retirée, puce `[x]` raccourcie.
