### PR TITLE
moteur: journaliser via logging au lieu de print (B3)

### DIFF
--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -352,8 +352,9 @@ future sans toucher au code** — seulement la config et les données.
       Sur la base de démo (2 141 communes × 55 objets) : 4 339 → 3 requêtes pour
       la matrice ACP (1,9 s → 1,1 s), et 20,3 s → 1,3 s pour `get_nb_inscrit`,
       qui interrogeait la base à *chaque* accès à `sujet_vote.date`.
-      *À noter* : `get_nb_inscrit` n'a aucun appelant dans le dépôt — à supprimer
-      si personne ne la réclame.
+      *À noter* : `get_nb_inscrit` n'a aucun appelant dans le code applicatif —
+      seul le test de non-régression sur le nombre de requêtes l'exerce. À
+      supprimer (avec son test) si personne ne la réclame.
 - [x] Rendre les imports **idempotents** (relançables sans doublons) :
       `update_or_create` plutôt que `save()` aveugle. C'était pire que prévu —
       le doublon n'attendait pas un rejeu : `add_initial_scrutin_en_cours` crée
@@ -370,7 +371,10 @@ future sans toucher au code** — seulement la config et les données.
 - [ ] `ScrutinAPI.get_percentage_oui_all_commune` laisse tomber `comptabilise` :
       le faire remonter jusqu'au contrat de vue, pour les cartes réel/estimé de
       la phase D.
-- [ ] Journalisation (`logging`) au lieu de `print`.
+- [x] Journalisation (`logging`) au lieu de `print` : cinq `print` dans les
+      scripts d'import → `logger.warning` / `logger.info`, et un `LOGGING`
+      minimal dans `settings.py` (console, niveau INFO) pour que les messages
+      d'avancement du jour J restent visibles.
 
 ### B4. Données historiques pérennes — **[I]** sources, **[M]** code
 - [ ] Script de (re)construction de la matrice historique depuis les données

--- a/election/settings.py
+++ b/election/settings.py
@@ -155,3 +155,18 @@ DEFAULT_AUTO_FIELD='django.db.models.AutoField'
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# Journalisation : les scripts du pipeline parlent via ``logging`` ; sans
+# handler sur la racine, Python n'affiche que WARNING et plus, et les messages
+# d'avancement du jour J (INFO) seraient perdus.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {'format': '{asctime} {levelname} {name}: {message}', 'style': '{'},
+    },
+    'handlers': {
+        'console': {'class': 'logging.StreamHandler', 'formatter': 'simple'},
+    },
+    'root': {'handlers': ['console'], 'level': 'INFO'},
+}

--- a/scripts/add_initial_scrutin_en_cours.py
+++ b/scripts/add_initial_scrutin_en_cours.py
@@ -1,6 +1,9 @@
 import json
+import logging
 
 from scrutin.models import Commune, ResultatCommunalEnCours, SujetVote
+
+logger = logging.getLogger(__name__)
 
 
 def clean_date(date_str):
@@ -25,7 +28,8 @@ def import_votation(path_votation):
                 try:
                     commune = Commune.get_unique_commune_by_ofs(data_commune['geoLevelnummer'])
                 except Exception:
-                    print(f'Commune not found: {data_commune["geoLevelnummer"]}: {data_commune["geoLevelname"]}')
+                    logger.warning('Commune not found: %s: %s',
+                                   data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue

--- a/scripts/create_fake_json_input.py
+++ b/scripts/create_fake_json_input.py
@@ -1,8 +1,11 @@
 import json
+import logging
 
 import numpy as np
 
 from scrutin.models import Commune, ResultatCommunalHistorique, SujetVote
+
+logger = logging.getLogger(__name__)
 
 p_rejection = 0.95
 
@@ -30,7 +33,8 @@ def run(*args):
                 try:
                     commune = Commune.get_unique_commune_by_ofs(data_commune['geoLevelnummer'])
                 except Exception:
-                    print(f'Commune not found: {data_commune["geoLevelnummer"]}: {data_commune["geoLevelname"]}')
+                    logger.warning('Commune not found: %s: %s',
+                                   data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue

--- a/scripts/import_metadata_commune.py
+++ b/scripts/import_metadata_commune.py
@@ -1,6 +1,10 @@
+import logging
+
 import pandas as pd
 
 from scrutin.models import Commune
+
+logger = logging.getLogger(__name__)
 
 
 def  import_commune(path_commune):
@@ -14,7 +18,8 @@ def  import_commune(path_commune):
             commune_db.degre_urbanisation = row_commune.HR_GDETYP2012_L1_Name_fr
             commune_db.save()
         except Exception:
-            print(f'unable to find info for {row_commune.Name_fr} with numero OFS {row_commune.CODE_OFS}')
+            logger.warning('unable to find info for %s with numero OFS %s',
+                           row_commune.Name_fr, row_commune.CODE_OFS)
 
 
 

--- a/scripts/update_scrutin_en_cours.py
+++ b/scripts/update_scrutin_en_cours.py
@@ -1,6 +1,9 @@
 import json
+import logging
 
 from scrutin.models import Commune, ResultatCommunalEnCours, SujetVote
+
+logger = logging.getLogger(__name__)
 
 
 def clean_date(date_str):
@@ -56,7 +59,8 @@ def import_votation(path_votation, commune_to_import):
                 try:
                     commune = Commune.get_unique_commune_by_ofs(data_commune['geoLevelnummer'])
                 except Exception:
-                    print(f'Commune not found: {data_commune["geoLevelnummer"]}: {data_commune["geoLevelname"]}')
+                    logger.warning('Commune not found: %s: %s',
+                                   data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
                 if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
                     continue
@@ -79,5 +83,6 @@ def run(*args):
         raise SystemExit("usage: runscript update_scrutin_en_cours "
                          "--script-args <json_precedent> <json_courant>")
     commune_to_import = get_new_commune(args[0], args[1])
-    print(commune_to_import)
+    logger.info('%d nouvelles communes dépouillées : %s',
+                len(commune_to_import), sorted(commune_to_import))
     import_votation(args[1], commune_to_import)


### PR DESCRIPTION
## Résumé
- Les cinq `print` des scripts d'import (`add_initial_scrutin_en_cours`, `update_scrutin_en_cours`, `create_fake_json_input`, `import_metadata_commune`) passent par `logging` : `warning` pour les communes introuvables, `info` pour la liste des communes nouvellement dépouillées.
- `LOGGING` minimal dans `settings.py` (console, niveau INFO), sinon les messages INFO seraient perdus.
- Plan : B3 « journalisation » coché ; la note sur `get_nb_inscrit` corrigée (le test de non-régression sur les requêtes l'appelle désormais).

## Vérification
`ruff check .` propre, `pytest` : 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)