### PR TITLE
moteur: 404 propre sur la route attrape-tout des pages statiques (B1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ mais les cartes **ne distinguent donc pas visuellement réel et estimé**.
 | `scrutin` | Cœur métier : tous les modèles, la logique d'extrapolation, la vue d'accueil, le CSS et le logo. |
 | `pca` | Modèle `PCAResult` (6 coordonnées par commune) + vue nuage de points ACP colorée par langue. |
 | `carte` | `carte/API.py` : cartes choroplèthes Plotly sur le GeoJSON communal. |
-| `page_statique` | Pages éditables en base (Méthodes, Contact), servies par une route attrape-tout `path("<str>", …)`. |
+| `page_statique` | Pages éditables en base (Méthodes, Contact), servies par la route attrape-tout `path("<slug:url>", …)` (404 si absente). |
 
 ### Modèles (`scrutin/models.py`)
 `Canton` → `District` → `Commune` ; `SujetVote` (un objet de votation) ;

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -323,8 +323,11 @@ future sans toucher au code** — seulement la config et les données.
       - [x] pandas : `fillna(method='ffill')` déprécié → `.ffill()` (populate_voix) ;
       - [ ] plotly : `px.choropleth_mapbox` déprécié dans les versions récentes →
         `px.choropleth_map` (MapLibre) ; vérifier le rendu des cartes ;
-      - [ ] la route attrape-tout `path("<str>", …)` fonctionne mais mérite
-        `path("<slug:url>", …)` + 404 propre au lieu d'une exception brute.
+      - [x] la route attrape-tout `path("<str>", …)` → `path("<slug:url>", …)`
+        + `get_object_or_404` : une URL inconnue (favicon, page absente de la
+        base) renvoie 404 au lieu d'un 500. *Reste côté I* : un `404.html`
+        dans la charte, et les liens `methode`/`contact`/`NA` de `base.html`
+        qui pointent sur des pages que `peupler_demo` ne crée pas.
 - [x] Passer les scripts `runscript` en **management commands Django natives**
       (`python manage.py <nom> [args]`, `--help`). `scripts/` a disparu, les
       commandes vivent dans `scrutin/management/commands/` (et `populate_pca`

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -326,8 +326,7 @@ future sans toucher au code** — seulement la config et les données.
       - [x] la route attrape-tout `path("<str>", …)` → `path("<slug:url>", …)`
         + `get_object_or_404` : une URL inconnue (favicon, page absente de la
         base) renvoie 404 au lieu d'un 500. *Reste côté I* : un `404.html`
-        dans la charte, et les liens `methode`/`contact`/`NA` de `base.html`
-        qui pointent sur des pages que `peupler_demo` ne crée pas.
+        dans la charte. Les liens morts du menu sont traités en D1.
 - [x] Passer les scripts `runscript` en **management commands Django natives**
       (`python manage.py <nom> [args]`, `--help`). `scripts/` a disparu, les
       commandes vivent dans `scrutin/management/commands/` (et `populate_pca`
@@ -454,8 +453,30 @@ Dans les deux cas :
 - [ ] Courbe de **convergence de la soirée** : les instantanés `Extrapolation`
       horodatés sont déjà en base, il n'y a qu'à les tracer (projection vs heure,
       avec le résultat final en ligne de référence).
-- [ ] Page « Méthodes » réécrite ; passer `page_statique` (contenu en DB) à des
-      fichiers markdown versionnés rendus par Django.
+- [x] **Décidé le 2026-09-01 : `page_statique` reste en base**, contre l'idée
+      initiale de ce plan (fichiers markdown versionnés). L'app date de 2022,
+      fait vingt lignes, ne coûte rien à maintenir, et corriger une coquille un
+      soir de votation ne demande ni commit ni redémarrage : le miroir statique
+      reprend la correction au tour de boucle suivant. Le prix accepté : ce
+      contenu échappe à git, donc ni revue, ni historique, ni retour arrière.
+      Ce qui était réellement bancal, ce n'est pas le stockage mais la
+      **coupure menu / contenu** : les onglets sont en dur dans `base.html`,
+      donc ajouter une page oblige de toute façon à éditer le gabarit, et une
+      page écrite dans un clone n'existe pas dans l'autre. D'où les trois
+      tâches ci-dessous, qui remplacent la migration vers markdown.
+- [ ] **[M]** Menu construit depuis la base : un *context processor* de
+      `page_statique` injecte les `PageStatique` dans tous les gabarits.
+      Prévoir un champ `ordre` et sa migration pour fixer l'ordre des onglets,
+      sinon tri par titre.
+- [ ] **[I]** `base.html` boucle sur ces pages au lieu des trois `<a>` en dur.
+      Accueil et Cartes restent écrits à la main : ce sont de vraies routes,
+      pas des pages en base. Au passage, l'onglet Cartes pointe sur `NA`, qui
+      n'existe pas : la route est `/cartes`.
+- [ ] **[M]** `peupler_demo` sème « Méthodes » et « Contact » : un clone frais
+      doit avoir un menu qui marche, alors qu'aujourd'hui ces deux onglets
+      tombent en 404. Attention, `_vider()` ne purge pas `PageStatique` : soit
+      l'ajouter à la liste, soit passer par `get_or_create`.
+- [ ] **[2]** Page « Méthodes » réécrite — le contenu lui-même, pas le support.
 - [ ] Validation rétrospective : rejouer les votations passées et publier l'erreur
       de projection en fonction de l'avance du dépouillement.
 

--- a/election/urls.py
+++ b/election/urls.py
@@ -26,5 +26,5 @@ urlpatterns = [
     path("", home_view, name="home"),
     path("cartes", carte_view, name="cartes"),
     path("pca", pca_view, name="PCA"),
-    path("<str>", static_view)
+    path("<slug:url>", static_view, name="page"),
 ]

--- a/page_statique/views.py
+++ b/page_statique/views.py
@@ -1,14 +1,8 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from page_statique.models import PageStatique
 
 
-# a useless comment here.
-def static_view(requete, *args, **kwargs):
-    pages = PageStatique.objects.filter(url = requete.path[1:])
-    if len(pages) == 1:
-        page = pages[0]
-    else:
-        raise Exception(requete.path)
-
-    return render(requete, "static.html", {"page_content" : page})
+def static_view(requete, url):
+    page = get_object_or_404(PageStatique, url=url)
+    return render(requete, "static.html", {"page_content": page})

--- a/tests/test_page_statique.py
+++ b/tests/test_page_statique.py
@@ -1,0 +1,23 @@
+"""La route attrape-tout des pages éditables renvoie un 404 propre.
+
+Elle levait une ``Exception`` brute (donc un 500) pour toute URL inconnue,
+y compris un simple favicon demandé par le navigateur.
+"""
+
+import pytest
+
+from page_statique.models import PageStatique
+
+pytestmark = pytest.mark.django_db
+
+
+def test_une_page_existante_est_servie(client):
+    PageStatique.objects.create(titre="Méthodes", contenu="<p>ACP</p>", url="methodes")
+    reponse = client.get("/methodes")
+    assert reponse.status_code == 200
+    assert "ACP" in reponse.content.decode()
+
+
+@pytest.mark.parametrize("url", ["/inconnue", "/favicon.ico", "/a/b", "/methodes/"])
+def test_une_url_inconnue_renvoie_404(client, url):
+    assert client.get(url).status_code == 404


### PR DESCRIPTION
Dernier point ouvert de B1.

- `election/urls.py` : `path("<str>", …)` → `path("<slug:url>", static_view, name="page")`.
- `page_statique/views.py` : `get_object_or_404` au lieu d'une `Exception` brute. Une URL inconnue (favicon, `/a/b`, page absente de la base) renvoie 404 au lieu d'un 500.
- `tests/test_page_statique.py` : page existante servie, quatre URL inconnues en 404.

Deux suites côté I, notées dans le plan : un `404.html` dans la charte (Django sert un texte nu sinon), et les liens `methode` / `contact` / `NA` de `base.html`, qui pointent sur des pages que `peupler_demo` ne crée pas et tombent donc en 404 sur la base fictive.

33 tests, ruff propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
