### PR TITLE
moteur: reconstruire et prolonger l'historique communal (B4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Amorçage, **dans cet ordre** (chaque étape dépend de la précédente) :
 populate_commune          # cantons, districts, communes
 import_metadata_commune   # langue, degré d'urbanisation
 populate_voix             # 55 votations historiques  (⚠ supprime tous les SujetVote)
+                          #   ou : importer_historique <json…> (open data fédéral)
 set_nb_voix_commune       # Commune.nb_voix = électeurs de la dernière votation
 populate_pca              # ACP → PCAResult          (⚠ supprime tous les PCAResult)
 add_initial_scrutin_en_cours <json_du_scrutin>   # lignes vides du jour J
@@ -113,6 +114,17 @@ sème les lignes vides (`get_or_create`), `update_scrutin_en_cours` les remplit
 (`update_or_create`). Il n'y a donc jamais qu'une ligne `ResultatCommunalEnCours` par
 commune et par objet — l'invariant n'est pas garanti par la base, seulement par
 le code et `tests/test_import_idempotent.py`.
+
+Le lendemain du scrutin, `archiver_scrutin [--date AAAA-MM-JJ]` verse les
+résultats **comptabilisés** du jour J dans `ResultatCommunalHistorique` :
+l'ACP gagne une votation sans réimporter quoi que ce soit. Les lignes
+`comptabilise=False` sont ignorées — ce sont les estimations écrites par
+`run_extrapolation`, les archiver nourrirait l'ACP de chiffres inventés.
+
+`importer_historique <json…>` reconstruit l'historique depuis les JSON de
+l'open data fédéral, au même format que le jour J. Il remplace
+`donnee_federale_v3.txt`, fichier hors dépôt au format exotique dont il ne
+reste aucune copie sur la machine du projet.
 
 `create_fake_json_input <json_du_scrutin> [<sortie>]` fabrique un JSON
 de test en rejouant d'anciens résultats sur 5 % des communes tirées au hasard :

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -306,9 +306,11 @@ mise à jour à l'époque ; corrigé le 2026-08-30 en relisant le repo.)*
       fichiers sources : liste des communes, méta-info (langue, urbanisation).
 - [ ] Documenter la provenance de `donnee_federale_v3.txt` (55 votations
       historiques) et le format attendu — c'est l'intrant de l'ACP, il est
-      aujourd'hui irremplaçable s'il est perdu. **À vérifier : en existe-t-il
-      encore une copie quelque part ?** Sinon, prévoir un script de
-      reconstruction depuis opendata.swiss (B4).
+      aujourd'hui irremplaçable s'il est perdu. **Vérifié le 2026-09-02 : plus
+      aucune copie sur la machine du projet** (recherche sur `/home`, `/srv`,
+      `/opt`, `/tmp`). Le script de reconstruction existe désormais
+      (`importer_historique`, B4) ; reste à rassembler les JSON sources, ce qui
+      est du sourcing, donc voie I.
 
 ---
 
@@ -386,12 +388,17 @@ future sans toucher au code** — seulement la config et les données.
       d'avancement du jour J restent visibles.
 
 ### B4. Données historiques pérennes — **[I]** sources, **[M]** code
-- [ ] Script de (re)construction de la matrice historique depuis les données
-      ouvertes de la Confédération (opendata.swiss / BFS), pour ne plus dépendre
-      du fichier `donnee_federale_v3.txt` au format exotique.
-- [ ] Mettre à jour l'historique après chaque votation (les résultats définitifs
-      du jour J rejoignent `ResultatCommunalHistorique` → l'ACP se bonifie toute seule). En faire une
-      management command : `manage.py archiver_scrutin`.
+- [x] Script de (re)construction de la matrice historique depuis les données
+      ouvertes de la Confédération : `manage.py importer_historique <json…>`,
+      qui lit le **même format que le jour J** (un fichier par dimanche de
+      votation) et écrit en `update_or_create`. Testé hors ligne sur des JSON
+      synthétiques. *Reste côté I* : rassembler les fichiers des 55 votations
+      et vérifier le résultat sur données réelles — le sourcing est voie I.
+- [x] Mettre à jour l'historique après chaque votation : `manage.py
+      archiver_scrutin [--date]`. **N'archive que les lignes
+      `comptabilise=True`** ; les autres portent les estimations de
+      `run_extrapolation`, et les archiver nourrirait l'ACP de chiffres
+      inventés. Vérifié aussi sur la base fictive.
 
 ### B5. Communes dans le temps — fusions et mutations (voir Partie 6) **[2]**
 Chantier structurant de la phase B : remplacer les cinq rustines actuelles

--- a/scrutin/management/commands/archiver_scrutin.py
+++ b/scrutin/management/commands/archiver_scrutin.py
@@ -1,0 +1,53 @@
+"""Fait passer les résultats définitifs du jour J dans l'historique.
+
+Une fois le dépouillement terminé, `ResultatCommunalEnCours` contient le
+résultat réel de chaque commune : il rejoint `ResultatCommunalHistorique`, et
+l'ACP se bonifie d'une votation à chaque scrutin.
+
+**Seules les lignes `comptabilise=True` sont archivées.** `run_extrapolation`
+écrit ses estimations dans les lignes des communes non dépouillées : les
+archiver reviendrait à nourrir l'ACP avec des chiffres inventés.
+"""
+
+from django.core.management.base import BaseCommand
+
+from scrutin.models import ResultatCommunalEnCours, ResultatCommunalHistorique, SujetVote
+
+
+def archiver(date):
+    """Archive les résultats comptabilisés du scrutin. Renvoie (archivés, ignorés)."""
+    sujets = SujetVote.objects.filter(date=date)
+    lignes = ResultatCommunalEnCours.objects.filter(sujet_vote__in=sujets)
+    archives = ignores = 0
+    for ligne in lignes.select_related('commune', 'sujet_vote'):
+        if not ligne.comptabilise:
+            ignores += 1
+            continue
+        ResultatCommunalHistorique.objects.update_or_create(
+            commune=ligne.commune,
+            sujet_vote=ligne.sujet_vote,
+            defaults={
+                "nombre_oui": ligne.nombre_oui,
+                "nombre_non": ligne.nombre_non,
+                "electeurs_inscrits": ligne.electeurs_inscrits,
+                "bulletins_rentres": ligne.bulletins_rentres,
+            },
+        )
+        archives += 1
+    return archives, ignores
+
+
+class Command(BaseCommand):
+    help = "Archive les résultats comptabilisés du dernier scrutin dans l'historique."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--date", help="Jour du scrutin (AAAA-MM-JJ). Défaut : le plus récent.")
+
+    def handle(self, *args, **options):
+        date = options["date"] or SujetVote.objects.latest('date').date
+        archives, ignores = archiver(date)
+        self.stdout.write(f"{archives} résultats archivés pour le {date}")
+        if ignores:
+            self.stdout.write(self.style.WARNING(
+                f"{ignores} lignes non comptabilisées ignorées : le dépouillement "
+                "n'est pas terminé, ou ces valeurs sont des estimations."))

--- a/scrutin/management/commands/importer_historique.py
+++ b/scrutin/management/commands/importer_historique.py
@@ -1,0 +1,74 @@
+"""Reconstruit l'historique communal depuis l'open data fédéral.
+
+L'historique venait de `donnee_federale_v3.txt`, un fichier hors dépôt dont il
+ne reste aucune copie sur les machines du projet. Les mêmes résultats sont
+publics : un JSON par dimanche de votation, au format déjà lu le jour J.
+
+    curl -O https://app-prod-static-voteinfo.s3.eu-central-1.amazonaws.com/v1/ogd/sd-t-17-02-20210613-eidgAbstimmung.json
+    python manage.py importer_historique sd-t-17-02-20210613-eidgAbstimmung.json
+
+Relançable : les résultats sont écrits en `update_or_create`.
+"""
+
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+
+from scrutin.management.commands.update_scrutin_en_cours import clean_date
+from scrutin.models import Commune, ResultatCommunalHistorique, SujetVote
+
+logger = logging.getLogger(__name__)
+
+
+def importer(chemin):
+    """Importe un JSON fédéral. Renvoie (sujets, résultats, communes inconnues)."""
+    with open(chemin) as f:
+        data = json.load(f)
+    date = clean_date(data['abstimmtag'])
+    nb_sujets = nb_resultats = 0
+    inconnues = set()
+    for objet in data['schweiz']['vorlagen']:
+        sujet, _ = SujetVote.objects.update_or_create(
+            sujet_id=objet['vorlagenId'],
+            defaults={"nom": objet['vorlagenTitel'][1]['text'], "date": date},
+        )
+        nb_sujets += 1
+        for canton in objet['kantone']:
+            for gemeinde in canton['gemeinden']:
+                resultat = gemeinde['resultat']
+                if resultat['jaStimmenAbsolut'] is None:
+                    continue
+                try:
+                    commune = Commune.get_unique_commune_by_ofs(gemeinde['geoLevelnummer'])
+                except Exception:
+                    inconnues.add(gemeinde['geoLevelname'])
+                    continue
+                ResultatCommunalHistorique.objects.update_or_create(
+                    commune=commune,
+                    sujet_vote=sujet,
+                    defaults={
+                        "nombre_oui": resultat['jaStimmenAbsolut'],
+                        "nombre_non": resultat['neinStimmenAbsolut'],
+                        "electeurs_inscrits": resultat['anzahlStimmberechtigte'],
+                        "bulletins_rentres": resultat['eingelegteStimmzettel'],
+                    },
+                )
+                nb_resultats += 1
+    return nb_sujets, nb_resultats, inconnues
+
+
+class Command(BaseCommand):
+    help = "Importe un ou plusieurs JSON fédéraux dans l'historique communal."
+
+    def add_arguments(self, parser):
+        parser.add_argument("json", nargs="+", help="un fichier par dimanche de votation")
+
+    def handle(self, *args, **options):
+        for chemin in options["json"]:
+            nb_sujets, nb_resultats, inconnues = importer(chemin)
+            self.stdout.write(
+                f"{chemin} : {nb_sujets} objets, {nb_resultats} résultats communaux")
+            if inconnues:
+                logger.warning('%d communes du JSON absentes de la base : %s',
+                               len(inconnues), ', '.join(sorted(inconnues)[:5]))

--- a/tests/test_archiver_scrutin.py
+++ b/tests/test_archiver_scrutin.py
@@ -1,0 +1,64 @@
+"""Archivage du jour J dans l'historique.
+
+Le piège : `run_extrapolation` écrit ses estimations dans les lignes des
+communes non dépouillées. Les archiver nourrirait l'ACP de chiffres inventés.
+"""
+
+import datetime
+
+import pytest
+
+from scrutin.management.commands.archiver_scrutin import archiver
+from scrutin.models import (
+    Canton,
+    Commune,
+    District,
+    ResultatCommunalEnCours,
+    ResultatCommunalHistorique,
+    SujetVote,
+)
+
+pytestmark = pytest.mark.django_db
+
+JOUR = datetime.date(2026, 9, 27)
+
+
+@pytest.fixture
+def scrutin():
+    canton = Canton.objects.create(nom="Vaud", abreviation="VD")
+    district = District.objects.create(nom="Lausanne", numero_ofs=1, canton=canton)
+    sujet = SujetVote.objects.create(nom="Objet", sujet_id=7000, date=JOUR)
+    for ofs, comptabilise in [(5586, True), (5587, False)]:
+        commune = Commune.objects.create(nom=f"C{ofs}", numero_ofs=ofs,
+                                         district=district, canton=canton)
+        ResultatCommunalEnCours.objects.create(
+            commune=commune, sujet_vote=sujet, nombre_oui=400, nombre_non=600,
+            electeurs_inscrits=1500, bulletins_rentres=1000,
+            electeur_election_precedente=1500, comptabilise=comptabilise)
+    return sujet
+
+
+def test_n_archive_que_les_communes_depouillees(scrutin):
+    archives, ignores = archiver(JOUR)
+
+    assert (archives, ignores) == (1, 1)
+    assert [r.commune.numero_ofs for r in ResultatCommunalHistorique.objects.all()] == [5586]
+
+
+def test_relancable_sans_doublon(scrutin):
+    archiver(JOUR)
+    archiver(JOUR)
+
+    assert ResultatCommunalHistorique.objects.count() == 1
+
+
+def test_ne_touche_pas_aux_autres_scrutins(scrutin):
+    autre = SujetVote.objects.create(nom="Vieux", sujet_id=6000,
+                                     date=datetime.date(2020, 1, 1))
+    ResultatCommunalHistorique.objects.create(
+        commune=Commune.objects.first(), sujet_vote=autre, nombre_oui=1,
+        nombre_non=2, electeurs_inscrits=3, bulletins_rentres=3)
+
+    archiver(JOUR)
+
+    assert ResultatCommunalHistorique.objects.get(sujet_vote=autre).nombre_oui == 1

--- a/tests/test_import_historique.py
+++ b/tests/test_import_historique.py
@@ -1,0 +1,87 @@
+"""Reconstruction de l'historique communal depuis un JSON fédéral.
+
+Le fichier `donnee_federale_v3.txt` qui alimentait l'ACP n'existe plus. Cette
+commande le remplace par la source publique, au format du jour J.
+"""
+
+import json
+
+import pytest
+
+from scrutin.management.commands.importer_historique import importer
+from scrutin.models import Canton, Commune, District, ResultatCommunalHistorique, SujetVote
+
+pytestmark = pytest.mark.django_db
+
+
+def ecrire_json(chemin, communes, nb_objets=1):
+    """`communes` : liste de (numero_ofs, nom, oui, non) ou oui=None si non dépouillée."""
+    objets = []
+    for i in range(nb_objets):
+        objets.append({
+            "vorlagenId": 6000 + i,
+            "vorlagenTitel": [{"text": f"DE {i}"}, {"text": f"Objet {i}"}],
+            "kantone": [{"gemeinden": [
+                {
+                    "geoLevelnummer": str(ofs),
+                    "geoLevelname": nom,
+                    "resultat": {
+                        "jaStimmenAbsolut": oui,
+                        "neinStimmenAbsolut": non,
+                        "anzahlStimmberechtigte": 1000,
+                        "eingelegteStimmzettel": None if oui is None else oui + non,
+                    },
+                }
+                for ofs, nom, oui, non in communes
+            ]}],
+        })
+    chemin.write_text(json.dumps({"abstimmtag": "20210613", "schweiz": {"vorlagen": objets}}))
+    return str(chemin)
+
+
+@pytest.fixture
+def commune():
+    canton = Canton.objects.create(nom="Vaud", abreviation="VD")
+    district = District.objects.create(nom="Lausanne", numero_ofs=1, canton=canton)
+    return Commune.objects.create(nom="Lausanne", numero_ofs=5586, district=district, canton=canton)
+
+
+def test_importe_les_resultats_et_cree_les_sujets(tmp_path, commune):
+    chemin = ecrire_json(tmp_path / "v.json", [(5586, "Lausanne", 400, 600)], nb_objets=2)
+
+    nb_sujets, nb_resultats, inconnues = importer(chemin)
+
+    assert (nb_sujets, nb_resultats, inconnues) == (2, 2, set())
+    assert SujetVote.objects.count() == 2
+    assert str(SujetVote.objects.first().date) == "2021-06-13"
+    resultat = ResultatCommunalHistorique.objects.first()
+    assert (resultat.nombre_oui, resultat.nombre_non, resultat.bulletins_rentres) == (400, 600, 1000)
+
+
+def test_relancable_sans_doublon(tmp_path, commune):
+    chemin = ecrire_json(tmp_path / "v.json", [(5586, "Lausanne", 400, 600)])
+
+    importer(chemin)
+    importer(chemin)
+
+    assert ResultatCommunalHistorique.objects.count() == 1
+    assert SujetVote.objects.count() == 1
+
+
+def test_ignore_une_commune_absente_de_la_base(tmp_path, commune):
+    chemin = ecrire_json(tmp_path / "v.json",
+                         [(5586, "Lausanne", 400, 600), (9999, "Inconnue", 10, 20)])
+
+    _, nb_resultats, inconnues = importer(chemin)
+
+    assert nb_resultats == 1
+    assert inconnues == {"Inconnue"}
+
+
+def test_ignore_une_commune_non_depouillee(tmp_path, commune):
+    chemin = ecrire_json(tmp_path / "v.json", [(5586, "Lausanne", None, None)])
+
+    _, nb_resultats, _ = importer(chemin)
+
+    assert nb_resultats == 0
+    assert not ResultatCommunalHistorique.objects.exists()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,7 +18,14 @@ from django.core.management import call_command
 from page_statique.models import PageStatique
 from pca.models import PCAResult
 from scrutin.extrapolation import get_extrapolation
-from scrutin.models import Commune, ResultatCommunalEnCours, ScrutinAPI, SujetVote
+from scrutin.management.commands.archiver_scrutin import archiver
+from scrutin.models import (
+    Commune,
+    ResultatCommunalEnCours,
+    ResultatCommunalHistorique,
+    ScrutinAPI,
+    SujetVote,
+)
 
 NB_VOTATIONS_HISTORIQUES = 55
 
@@ -127,3 +134,18 @@ def test_l_extrapolation_corrige_le_biais_du_depouillement_partiel(base_demo):
 def test_la_demo_seme_les_pages_du_menu(base_demo):
     """Sans elles, les onglets Méthodes et Contact tombent en 404."""
     assert set(PageStatique.objects.values_list("url", flat=True)) == {"methode", "contact"}
+
+
+@pytest.mark.lent
+@pytest.mark.django_db
+def test_archiver_le_jour_j_ajoute_une_votation_a_l_historique(base_demo):
+    """L'ACP se bonifie à chaque scrutin, sans réimporter quoi que ce soit."""
+    avant = ResultatCommunalHistorique.objects.count()
+    jour = SujetVote.objects.latest("date").date
+    comptabilisees = ResultatCommunalEnCours.objects.filter(
+        sujet_vote__date=jour, comptabilise=True).count()
+
+    archives, ignores = archiver(jour)
+
+    assert archives == comptabilisees
+    assert ResultatCommunalHistorique.objects.count() == avant + comptabilisees


### PR DESCRIPTION
Les deux points de B4, côté **[M]** uniquement. Aucune donnée réelle nécessaire : tout est testé hors ligne.

**`importer_historique <json…>`** reconstruit l'historique depuis l'open data fédéral, au même format que celui lu le jour J, un fichier par dimanche de votation. Écriture en `update_or_create`, communes appariées par numéro OFS, communes inconnues et non dépouillées ignorées avec un décompte.

Motivation : `donnee_federale_v3.txt` alimentait l'ACP, vivait hors du dépôt, et le plan demandait de vérifier s'il en restait une copie. **Réponse : aucune sur cette machine**, recherche faite sur `/home`, `/srv`, `/opt` et `/tmp`. Le fichier n'est plus un point de défaillance unique.

**`archiver_scrutin [--date]`** verse les résultats du jour J dans l'historique, pour que l'ACP se bonifie à chaque votation sans réimport. Le piège traité explicitement : `run_extrapolation` écrit ses estimations dans les lignes des communes non dépouillées, donc seules les lignes `comptabilise=True` sont archivées. Les autres sont comptées et signalées.

**Tests** : quatre sur l'import depuis des JSON synthétiques, trois sur l'archivage, et un sur la base fictive qui vérifie que l'historique grandit exactement du nombre de communes dépouillées. 44 tests, ruff propre.

**Ce que je n'ai pas fait**, et qui reste voie I : rassembler les JSON des 55 votations et valider l'import sur données réelles. Le sourcing des données est étiqueté **[I]** dans le plan, je m'y suis tenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
