### PR TITLE
moteur: peupler_demo écrit les trois degrés d'urbanisation (A6)

### DIFF
--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -310,8 +310,9 @@ mise à jour à l'époque ; corrigé le 2026-08-30 en relisant le repo.)*
       `agvch_niveaux_2026-01-01.csv` (endpoint `levels`), lu par
       `populate_commune` **et** `import_metadata_commune`. Une ligne par
       commune, la hiérarchie déjà jointe.
-- [ ] **Degré d'urbanisation : aligner `peupler_demo` [M]** — l'échelle
-      officielle `DEGURB2021` en a trois, `peupler_demo` n'en écrit que deux.
+- [x] **Degré d'urbanisation : aligner `peupler_demo` [M]** — les trois degrés
+      de l'échelle officielle `DEGURB2021` (urbain / intermédiaire / rural),
+      dans des proportions proches du réel.
 - [ ] Documenter la provenance de `donnee_federale_v3.txt` (55 votations
       historiques) et le format attendu — c'est l'intrant de l'ACP, il est
       aujourd'hui irremplaçable s'il est perdu. **À vérifier : en existe-t-il

--- a/scrutin/management/commands/peupler_demo.py
+++ b/scrutin/management/commands/peupler_demo.py
@@ -84,6 +84,15 @@ def sigmoide(x):
     return 1.0 / (1.0 + math.exp(-x))
 
 
+def degre_urbanisation(urbanite):
+    """Les trois degrés de DEGURB2021, dans des proportions proches du réel."""
+    if urbanite > 1.5:
+        return "urbain"
+    if urbanite > 0:
+        return "intermédiaire"
+    return "rural"
+
+
 class Command(BaseCommand):
     help = "Peuple la base avec des données fictives à l'échelle réelle."
 
@@ -183,7 +192,7 @@ class Command(BaseCommand):
                 canton=cantons[id_canton],
                 district=districts_db[p["bezkId"]],
                 langue="français" if latin else "allemand",
-                degre_urbanisation="urbain" if urbanite > 0.5 else "rural",
+                degre_urbanisation=degre_urbanisation(urbanite),
                 nb_voix=electeurs,
             ))
             profils[p["vogeId"]] = (urbanite, latin, electeurs)


### PR DESCRIPTION
Dernier point [M] d'A6 après #32.

`import_metadata_commune` traduit `DEGURB2021` en trois degrés (urbain / intermédiaire / rural), mais `peupler_demo` n'en écrivait que deux. La base fictive et la base réelle portent maintenant les mêmes étiquettes.

Répartition obtenue avec la graine par défaut, contre le référentiel AGVCH au 01.01.2026 :

| Degré | `peupler_demo` | Réel |
|---|---|---|
| urbain | 136 | 135 |
| intermédiaire | 914 | 959 |
| rural | 1091 | 1016 |

Aucun code applicatif ne lit `degre_urbanisation` aujourd'hui (ni vue, ni carte, ni ACP) : la voie I dispose donc des trois valeurs le jour où elle voudra colorer par urbanisation. `ruff` et les 46 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
