### PR TITLE
plan: donnee_federale_v3.txt était un export manuel de STAT-TAB (A6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,8 @@ Le script contient des valeurs codées en dur : `192.168.1.20:8000`, `/srv/html/
    tâche A6). Le référentiel des communes (`populate_commune`,
    `import_metadata_commune`) lit désormais `data/agvch_niveaux_2026-01-01.csv`,
    versionné, comme `carte/API.py`. Restent hors du dépôt, en attendant B4 :
-   `donnee_federale_v3.txt` (l'historique, dont plus aucune copie n'existe) et
+   `donnee_federale_v3.txt` (l'historique, dont plus aucune copie n'existe —
+   c'était un export manuel du cube STAT-TAB que B4 interroge par API) et
    les `votation_septembre_2022_*.json` du jour J.
 
 **Valeurs codées en dur** — **corrigées** (jalon 3, tâche B2)

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -312,11 +312,14 @@ mise à jour à l'époque ; corrigé le 2026-08-30 en relisant le repo.)*
       commune, la hiérarchie déjà jointe.
 - [ ] **Degré d'urbanisation : aligner `peupler_demo` [M]** — l'échelle
       officielle `DEGURB2021` en a trois, `peupler_demo` n'en écrit que deux.
-- [ ] Documenter la provenance de `donnee_federale_v3.txt` (55 votations
-      historiques) et le format attendu — c'est l'intrant de l'ACP, il est
-      aujourd'hui irremplaçable s'il est perdu. **À vérifier : en existe-t-il
-      encore une copie quelque part ?** Sinon, prévoir un script de
-      reconstruction depuis opendata.swiss (B4).
+- [x] Documenter la provenance de `donnee_federale_v3.txt` (55 votations
+      historiques). **Il n'en reste aucune copie.** Son format, tel que
+      `populate_voix` le lit (séparateur `;`, communes préfixées par `......`,
+      `...` pour une valeur absente), est celui d'un export manuel du cube
+      STAT-TAB de l'OFS `px-x-1703030000_101` — la source même que B4
+      interroge par API. Le fichier n'était donc pas irremplaçable :
+      `importer_historique` (B4) le reconstruit, et `populate_voix` disparaît
+      avec lui.
 
 ---
 


### PR DESCRIPTION
Documentation seule, aucun code. Ferme la dernière question ouverte d'A6 : d'où venait `donnee_federale_v3.txt`, et en reste-t-il une copie ?

**Aucune copie** ne subsiste sur les machines du projet. Mais sa provenance se lit dans `populate_voix` : le fichier repérait les communes au préfixe `......` et les valeurs absentes à `...`. C'est exactement l'étiquetage du cube STAT-TAB `px-x-1703030000_101` (« Canton (-) / District (>>) / Commune (......) »), vérifié sur l'API aujourd'hui. Le fichier était donc un export manuel de STAT-TAB, avec 55 objets cochés à la main.

Conséquence : il n'était pas irremplaçable. `importer_historique` (B4, #31) reconstruit le même contenu depuis la même source, par API, et `populate_voix` disparaît avec lui.

#31 coche déjà cet item dans sa version du plan : à son rebase, garder cette rédaction, qui ajoute la provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
