### PR TITLE
moteur: une commune sans profil ne fait plus tomber la projection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ le sont déjà.
 Garde-fou : sous **7 communes dépouillées**, `get_extrapolation` renvoie `0.5, 0.5, 0`
 plutôt qu'un ajustement sur trop peu de points.
 
+Une commune sans profil ACP ne fait jamais tomber la projection : déjà
+dépouillée, ses bulletins comptent mais elle ne sert pas à ajuster le modèle ;
+pas encore rentrée, elle est projetée avec le profil moyen de son district. Le
+cas est courant — une commune qui se met à publier ses résultats séparément n'a
+pas d'historique, donc pas de profil.
+
 À noter : `manage.py run_extrapolation` **écrit les valeurs extrapolées dans les
 lignes `ResultatCommunalEnCours`** des communes non dépouillées (tout en laissant
 `comptabilise=False`). C'est ce qui permet aux cartes d'afficher toute la Suisse —

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -430,8 +430,18 @@ Reste de B5, une fois B4 fait :
       l'API AGVCH (`api/communes/levels`, CSV, sans clé) au lieu des fichiers
       non versionnés de `../data`. *Fait en A6* — et `populate_commune` lit le
       même fichier, la hiérarchie y étant déjà jointe.
-- [ ] Jour J blindé : commune sans profil ACP → repli sur le profil moyen du
-      district + log, jamais une exception qui tue l'extrapolation.
+- [x] Jour J blindé : commune sans profil ACP → repli sur le profil moyen du
+      district + log, jamais une exception qui tue l'extrapolation. Distinction
+      selon l'état : une commune **déjà dépouillée** voit ses bulletins comptés
+      mais ne sert pas de point d'appui au modèle, un profil inventé faussant
+      l'ajustement ; une commune **pas encore rentrée** est projetée avec le
+      profil moyen de son district, à défaut le profil moyen national.
+      Les trois exclusions nominatives (`Rüti bei Lyssach`, `Jaberg`) des
+      scripts du jour J disparaissent : elles disaient par des noms ce que le
+      code exprime maintenant par la condition. Rejeu du 14 juin avec les deux
+      communes réintégrées, à moitié dépouillé : 45,28 % et 53,24 % pour
+      45,2 % et 52,5 % réels, contre 45,4 % et 53,4 % quand elles étaient
+      jetées.
 - [ ] **[I]** GeoJSON communal à jour — voir Partie 6.
 
 ---

--- a/scrutin/extrapolation.py
+++ b/scrutin/extrapolation.py
@@ -1,10 +1,44 @@
+import logging
+
 import numpy as np
 import scipy.optimize
 
 from pca.models import PCAResult
 from scrutin.models import ResultatCommunalEnCours
 
+logger = logging.getLogger(__name__)
+
 nb_component = 6
+
+COORDONNEES = ('coordinate_1', 'coordinate_2', 'coordinate_3',
+               'coordinate_4', 'coordinate_5', 'coordinate_6')
+
+
+def profils_de_repli():
+    """Profil moyen par district, et profil moyen national.
+
+    Doublure pour les communes absentes de l'ACP. Il y en a toujours : une
+    commune à l'historique incomplet en est écartée, et c'est le cas de celles
+    qui viennent d'être publiées séparément après avoir voté à l'urne d'une
+    voisine. Leur prêter le profil moyen de leurs voisines vaut mieux que de
+    les ignorer, et bien mieux que de faire tomber la projection.
+
+    Les composantes étant centrées, la moyenne nationale vaut à peu près zéro :
+    une commune sans district connu est donc traitée comme une commune
+    moyenne, le pari le moins aventureux.
+    """
+    par_district = {}
+    tous = []
+    for district_id, *coordonnees in PCAResult.objects.values_list(
+            'commune__district_id', *COORDONNEES):
+        profil = list(coordonnees[:nb_component])
+        par_district.setdefault(district_id, []).append(profil)
+        tous.append(profil)
+    if not tous:
+        return {}, [0.0] * nb_component
+    moyennes = {district_id: list(np.mean(profils, axis=0))
+                for district_id, profils in par_district.items()}
+    return moyennes, list(np.mean(tous, axis=0))
 
 def get_percentage(component, params):
     return np.sum(component * params[:-1]) + params[-1]
@@ -39,22 +73,33 @@ def get_extrapolation(sujet):
     data_for_interpolating_participation = []
     nbre_votant_approximated = []
     commune_without_result = []
-    PCAResult_dict = {
-        pca_result.commune_id: pca_result
+    profils = {
+        pca_result.commune_id: pca_result.get_component(nb_component)
         for pca_result in PCAResult.objects.all()
     }
-    for voix in ResultatCommunalEnCours.objects.filter(sujet_vote = sujet).order_by("commune"):
-        try:
-            pca = PCAResult_dict[voix.commune_id]
-        except KeyError as absent:
-            raise Exception(f'Commune pca not found: {voix.commune}') from absent
+    par_district, national = profils_de_repli()
+    for voix in (ResultatCommunalEnCours.objects.filter(sujet_vote=sujet)
+                 .select_related('commune').order_by("commune")):
+        profil = profils.get(voix.commune_id)
         if voix.comptabilise:
-            data_for_interpolating_pourcentage_oui.append((voix.get_pourcentage_oui(), pca.get_component(nb_component), voix.bulletins_rentres))
-            data_for_interpolating_participation.append((voix.get_real_participation(), pca.get_component(nb_component), voix.bulletins_rentres))
+            # Ses bulletins sont réels : ils comptent, profil ou pas.
             know_result_oui += voix.nombre_oui
             know_result_non += voix.nombre_non
+            if profil is None:
+                # Sans profil, elle ne peut pas servir de point d'appui au
+                # modèle : un profil de repli fausserait l'ajustement.
+                logger.warning("%s n'a pas de profil ACP : ses bulletins sont "
+                               "comptés, mais elle ne sert pas à ajuster le modèle",
+                               voix.commune)
+                continue
+            data_for_interpolating_pourcentage_oui.append((voix.get_pourcentage_oui(), profil, voix.bulletins_rentres))
+            data_for_interpolating_participation.append((voix.get_real_participation(), profil, voix.bulletins_rentres))
         else:
-            data_to_interpolate.append(pca.get_component(nb_component))
+            if profil is None:
+                profil = par_district.get(voix.commune.district_id, national)
+                logger.warning("%s n'a pas de profil ACP : projetée avec le "
+                               "profil moyen de son district", voix.commune)
+            data_to_interpolate.append(profil)
             nbre_votant_approximated.append(voix.electeur_election_precedente)
             commune_without_result.append(voix)
     if len(data_for_interpolating_participation) < 7:

--- a/scrutin/management/commands/add_initial_scrutin_en_cours.py
+++ b/scrutin/management/commands/add_initial_scrutin_en_cours.py
@@ -33,8 +33,6 @@ def import_votation(path_votation):
                     logger.warning('Commune not found: %s: %s',
                                    data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
-                if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
-                    continue
                 ResultatCommunalEnCours.objects.get_or_create(
                     commune=commune,
                     sujet_vote=sujet,

--- a/scrutin/management/commands/create_fake_json_input.py
+++ b/scrutin/management/commands/create_fake_json_input.py
@@ -43,8 +43,6 @@ def fabriquer(path_votation, path_sortie):
                     logger.warning('Commune not found: %s: %s',
                                    data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
-                if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
-                    continue
                 resultat_previous = get_result(commune, sujet)
                 if resultat_previous is None:
                     continue

--- a/scrutin/management/commands/update_scrutin_en_cours.py
+++ b/scrutin/management/commands/update_scrutin_en_cours.py
@@ -64,8 +64,6 @@ def import_votation(path_votation, commune_to_import):
                     logger.warning('Commune not found: %s: %s',
                                    data_commune["geoLevelnummer"], data_commune["geoLevelname"])
                     continue
-                if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
-                    continue
                 result = data_commune['resultat']
                 ResultatCommunalEnCours.objects.update_or_create(
                     commune=commune,

--- a/tests/test_extrapolation.py
+++ b/tests/test_extrapolation.py
@@ -22,6 +22,7 @@ from scrutin.extrapolation import (
     get_linear_parameter,
     get_percentage,
     nb_component,
+    profils_de_repli,
 )
 from scrutin.models import Canton, Commune, District, ResultatCommunalEnCours, SujetVote
 
@@ -200,15 +201,65 @@ def test_moins_de_sept_communes_depouillees_renvoie_le_repli():
 
 
 @pytest.mark.django_db
-def test_commune_sans_profil_acp_est_signalee():
-    """Une commune sans ``PCAResult`` doit lever une erreur explicite.
+def test_une_commune_sans_profil_ne_fait_pas_tomber_la_projection(caplog):
+    """Le scénario qui gelait la soirée.
 
-    C'est la cause racine des exclusions nominatives (Rüti bei Lyssach, Jaberg)
-    qui traînent dans les scripts du jour J : le message doit nommer la commune
-    fautive pour qu'un soir de scrutin reste diagnosticable.
+    Une commune sans ``PCAResult`` levait une exception, donc plus aucune
+    projection jusqu'à ce que quelqu'un s'en aperçoive. C'est arrivé pour de
+    vrai : une commune qui se met à publier ses résultats séparément n'a pas
+    d'historique, donc pas de profil. Elle est désormais projetée avec le
+    profil moyen de son district, et l'avertissement la nomme.
+    """
+    sujet, oui_reel, non_reel = peupler_base_lineaire(nb_communes=40, nb_comptees=13)
+    # Une commune pas encore dépouillée : c'est elle qu'il faut projeter.
+    PCAResult.objects.filter(commune__nom="Commune 20").delete()
+
+    _, extrapolation, _, sans_resultat, _, _ = get_extrapolation(sujet)
+
+    assert "Commune 20" in caplog.text
+    # Elle est projetée comme les autres, pas laissée de côté.
+    assert "Commune 20" in [voix.commune.nom for voix in sans_resultat]
+    assert extrapolation == pytest.approx(oui_reel / (oui_reel + non_reel), abs=0.01)
+
+
+@pytest.mark.django_db
+def test_les_bulletins_d_une_commune_comptee_sans_profil_sont_comptes(caplog):
+    """Ses voix sont réelles : elles entrent dans le dépouillement connu.
+
+    Elle ne peut pas servir de point d'appui au modèle — un profil inventé
+    fausserait l'ajustement — mais l'ignorer perdrait de vrais bulletins, ce
+    que faisaient les exclusions nominatives des scripts du jour J.
     """
     sujet, _, _ = peupler_base_lineaire(nb_communes=40, nb_comptees=13)
-    PCAResult.objects.filter(commune__nom="Commune 7").delete()
+    comptee = ResultatCommunalEnCours.objects.filter(
+        sujet_vote=sujet, comptabilise=True).order_by("commune").first()
+    PCAResult.objects.filter(commune=comptee.commune).delete()
 
-    with pytest.raises(Exception, match="Commune 7"):
-        get_extrapolation(sujet)
+    connu, _, _, _, _, _ = get_extrapolation(sujet)
+
+    assert comptee.commune.nom in caplog.text
+    lignes = ResultatCommunalEnCours.objects.filter(sujet_vote=sujet, comptabilise=True)
+    oui = sum(ligne.nombre_oui for ligne in lignes)
+    non = sum(ligne.nombre_non for ligne in lignes)
+    assert connu == pytest.approx(oui / (oui + non))
+
+
+@pytest.mark.django_db
+def test_le_profil_de_repli_est_la_moyenne_du_district():
+    """Deux districts aux profils opposés : le repli doit prendre le bon."""
+    peupler_base_lineaire(nb_communes=4, nb_comptees=4)
+    district = District.objects.get()
+    autre = District.objects.create(nom="Ailleurs", code_historique=2,
+                                    canton=district.canton)
+    lointaine = Commune.objects.create(nom="Lointaine", numero_ofs=9999,
+                                       canton=district.canton, district=autre)
+    PCAResult.objects.create(commune=lointaine, coordinate_1=10.0, coordinate_2=0.0,
+                             coordinate_3=0.0, coordinate_4=0.0, coordinate_5=0.0,
+                             coordinate_6=0.0)
+
+    par_district, national = profils_de_repli()
+
+    assert par_district[autre.id][0] == pytest.approx(10.0)
+    # Les quatre communes du premier district sont réparties de -1,5 à 1,5.
+    assert par_district[district.id][0] == pytest.approx(0.0)
+    assert national[0] == pytest.approx(10.0 / 5)


### PR DESCRIPTION
## Le défaut

`get_extrapolation` levait une exception dès qu'une commune du fichier du jour J n'avait pas de profil ACP. Trois scripts du pipeline masquaient le problème en écartant deux communes **par leur nom**, en dur :

```python
if (commune.nom in ['Rüti bei Lyssach', 'Jaberg']):
    continue
```

Le jour où une troisième arrive, la projection se fige pour toute la soirée et rien ne le signale. Ce n'est pas théorique : Jaberg a quitté son urne commune en mars 2018, Rüti bei Lyssach en mars 2021. Cinq communes bernoises sont encore dans ce cas.

## Ce que fait cette MR

Le code exprime la condition au lieu d'énumérer des noms.

| État de la commune | Sans profil ACP |
|---|---|
| Déjà dépouillée | Ses bulletins comptent, mais elle ne sert pas de point d'appui au modèle |
| Pas encore rentrée | Projetée avec le profil moyen de son district, à défaut le profil national |

Les deux cas journalisent la commune. Une commune déjà dépouillée porte de vrais bulletins : les jeter, ce que faisaient les exclusions nominatives, était une perte. En revanche lui prêter un profil inventé fausserait l'ajustement, donc elle n'entre pas dans la régression.

Les composantes de l'ACP étant centrées, le profil national vaut à peu près zéro : une commune dont le district est lui aussi inconnu est traitée comme une commune moyenne.

## Vérifié sur les vraies données

Rejeu du 14 juin 2026 avec les deux communes réintégrées, la moitié la plus petite des communes dépouillée. Résultats réels : 45,2 % et 52,5 %.

| Objet | Avant, communes jetées | Maintenant |
|---|---|---|
| Initiative « 10 millions » | 45,4 % | 45,28 % |
| Loi sur le service civil | 53,4 % | 53,24 % |

Les 2 117 communes du fichier sont désormais toutes présentes, contre 2 115. Les deux avertissements nomment bien Jaberg et Rüti bei Lyssach.

## Tests

Trois tests ajoutés : la projection ne tombe plus et la commune est bien projetée, les bulletins d'une commune dépouillée sans profil sont comptés, et le repli prend la moyenne du bon district. Le test qui exigeait l'exception est remplacé. Suite complète verte, 55 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)