### PR TITLE
interface: déplacer histogramme() dans scrutin/graphiques.py

### DIFF
--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -123,9 +123,9 @@ tout le monde voit exactement le même site.
       `tests/test_contrat.py`) et validé en PR à deux. `views.py` et la carte
       consomment le contrat (`resultats_par_commune` vit dans
       `scrutin/donnees.py`, pas besoin d'un `carte/donnees.py` à part). Le
-      Plotly de l'histogramme attend encore son déménagement de `views.py`
-      vers `graphiques.py` **[I]**, celui de la carte de `carte/API.py` vers
-      `carte/figure.py` **[I]**.
+      Plotly de l'histogramme a déménagé de `views.py` vers
+      `scrutin/graphiques.py` **[I]** ; celui de la carte attend encore son
+      passage de `carte/API.py` vers `carte/figure.py` **[I]**.
 
 **Conséquence sur le parallélisme** : la voie I ne démarre qu'une fois le
 jalon 0 franchi (A1–A3 + `peupler_demo`, ≈ 1 jour côté M) au lieu de démarrer

--- a/scrutin/graphiques.py
+++ b/scrutin/graphiques.py
@@ -1,0 +1,35 @@
+"""Figures Plotly de la page d'accueil (voie Interface).
+
+Ces fonctions ne consomment que le contrat de vue construit par
+`scrutin.donnees` : aucun accès à l'ORM ici.
+"""
+
+import plotly
+import plotly.express as px
+
+
+def clean_name(name):
+        if len(name.split('(')) > 1:
+            return name.split('(')[1].split(')')[0]
+        return "AVS-TVA"
+
+
+def histogramme(vue):
+    noms = [clean_name(sujet["nom"]) for sujet in vue["sujets"]]
+    connus = [sujet["oui_connu"] for sujet in vue["sujets"]]
+    extrapoles = [sujet["oui_extrapole"] for sujet in vue["sujets"]]
+    ddf = {
+        "sujet": noms + noms,
+        "pourcentage de oui": ["Déja dépouillés"] * len(connus) + ["Extrapolés"] * len(extrapoles),
+        "value": connus + extrapoles,
+    }
+    ddf["formated_value"] = [f"{100*v:.1f}%" for v in ddf["value"]]
+    return plotly.offline.plot(px.bar(ddf, x="sujet",
+                                      y='value',
+                                      color="pourcentage de oui",
+                                      barmode="group",
+                                      title="",
+                                      hover_name="sujet",
+                                      text="formated_value"),
+                               include_plotlyjs=False,
+                               output_type='div')

--- a/scrutin/views.py
+++ b/scrutin/views.py
@@ -1,39 +1,10 @@
 import datetime
 
-import plotly
-import plotly.express as px
 from django.shortcuts import render
 
 import carte.API as carte_api
 from scrutin.donnees import construire_vue_accueil
-
-
-def clean_name(name):
-        if len(name.split('(')) > 1:
-            return name.split('(')[1].split(')')[0]
-        return "AVS-TVA"
-
-
-def histogramme(vue):
-    """À déplacer dans scrutin/graphiques.py (voie Interface)."""
-    noms = [clean_name(sujet["nom"]) for sujet in vue["sujets"]]
-    connus = [sujet["oui_connu"] for sujet in vue["sujets"]]
-    extrapoles = [sujet["oui_extrapole"] for sujet in vue["sujets"]]
-    ddf = {
-        "sujet": noms + noms,
-        "pourcentage de oui": ["Déja dépouillés"] * len(connus) + ["Extrapolés"] * len(extrapoles),
-        "value": connus + extrapoles,
-    }
-    ddf["formated_value"] = [f"{100*v:.1f}%" for v in ddf["value"]]
-    return plotly.offline.plot(px.bar(ddf, x="sujet",
-                                      y='value',
-                                      color="pourcentage de oui",
-                                      barmode="group",
-                                      title="",
-                                      hover_name="sujet",
-                                      text="formated_value"),
-                               include_plotlyjs=False,
-                               output_type='div')
+from scrutin.graphiques import histogramme
 
 
 def home_view(requete, *args, **kwargs):


### PR DESCRIPTION
## Pourquoi

La couture données / présentation prévoit trois fichiers : `donnees.py` [M] construit le dict de vue, `graphiques.py` [I] le rend en HTML, `views.py` assemble et reste minuscule. L'histogramme était resté dans `views.py`, avec un `TODO` qui le disait.

## Ce que ça change

- Nouveau `scrutin/graphiques.py` : `histogramme()` et son helper `clean_name()`, déplacés **tels quels**. Un docstring de module rappelle la règle : aucun ORM ici, seulement le contrat de vue.
- `scrutin/views.py` se réduit à `home_view`, qui importe `histogramme`.
- `PLAN_MODERNISATION.md` : ce travail différé est fait, il ne reste que le passage de la carte de `carte/API.py` vers `carte/figure.py`.

Aucun changement de comportement : le code déplacé est identique, la page d'accueil rend la même figure.

## Vérifications

- `ruff check .` — passe
- `pytest -m "not lent"` — 42 passés

🤖 Generated with [Claude Code](https://claude.com/claude-code)