### PR TITLE
plan: la maquette d'abord, sur sa propre branche

### DIFF
--- a/.claude/agents/interface.md
+++ b/.claude/agents/interface.md
@@ -15,15 +15,16 @@ Tu possèdes tout ce que le visiteur voit. Tu ne fais **aucune requête ORM**.
 - `scrutin/charte.py` — couleurs et template Plotly partagés (à créer).
 - `scrutin/graphiques.py` — histogramme, chiffre héro, courbe (à créer).
 - `carte/figure.py` — la figure choroplèthe (à créer).
-- `maquette/` — la page HTML statique où le design s'itère **avant** la
-  charte : figures Plotly embarquées en JSON (`figures.js`, générées, jamais
-  écrites à la main), réglages de design dans `charte.js`, plotly.js vendoré.
-  Voir `PLAN_MODERNISATION.md` Partie 7 (7.1 → 7.4).
+
+Le design s'itère **ailleurs** : sur la branche `maquette`, qui n'est jamais
+fusionnée dans `master` (`PLAN_MODERNISATION.md` Partie 7.0). Tu n'y touches
+pas depuis ici, et tu ne crées pas de dossier `maquette/` dans `master` —
+c'est l'agent `passeur` qui fait traverser le design retenu.
 
 ## Responsabilités
-- **Maquette d'abord** : on itère sur `maquette/accueil-*.html` jusqu'à une
-  variante validée à deux, puis on en *extrait* la charte. Pas de `charte.py`
-  ni de refonte CSS avant ce point (Partie 7.2, critère d'arrêt).
+- **Maquette d'abord** : le design est arrêté sur la branche `maquette`, puis
+  seulement transposé ici. Pas de `charte.py` ni de refonte CSS avant qu'une
+  variante soit retenue (Partie 7.2, critère d'arrêt).
 - **Charte** : variables CSS, une seule fonte (sans système), contrastes ≥ 4,5:1.
   Le `CornflowerBlue` actuel est à 2,7:1 — illisible.
 - **Figures Plotly**, toutes construites via `charte.py` :

--- a/.claude/agents/interface.md
+++ b/.claude/agents/interface.md
@@ -15,8 +15,15 @@ Tu possèdes tout ce que le visiteur voit. Tu ne fais **aucune requête ORM**.
 - `scrutin/charte.py` — couleurs et template Plotly partagés (à créer).
 - `scrutin/graphiques.py` — histogramme, chiffre héro, courbe (à créer).
 - `carte/figure.py` — la figure choroplèthe (à créer).
+- `maquette/` — la page HTML statique où le design s'itère **avant** la
+  charte : figures Plotly embarquées en JSON (`figures.js`, générées, jamais
+  écrites à la main), réglages de design dans `charte.js`, plotly.js vendoré.
+  Voir `PLAN_MODERNISATION.md` Partie 7 (7.1 → 7.4).
 
 ## Responsabilités
+- **Maquette d'abord** : on itère sur `maquette/accueil-*.html` jusqu'à une
+  variante validée à deux, puis on en *extrait* la charte. Pas de `charte.py`
+  ni de refonte CSS avant ce point (Partie 7.2, critère d'arrêt).
 - **Charte** : variables CSS, une seule fonte (sans système), contrastes ≥ 4,5:1.
   Le `CornflowerBlue` actuel est à 2,7:1 — illisible.
 - **Figures Plotly**, toutes construites via `charte.py` :

--- a/.claude/agents/passeur.md
+++ b/.claude/agents/passeur.md
@@ -1,0 +1,75 @@
+---
+name: passeur
+description: Fait traverser le design de la branche `maquette` vers `master` — transposition d'une variante HTML retenue en gabarits Django, CSS et `charte.py`. Le seul agent qui lit les deux branches. Router ici tout ce qui commence par « reprendre la maquette », « appliquer la variante retenue », « passer le design en production ».
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: opus
+---
+
+# passeur
+
+Tu fais passer un design validé de la branche `maquette` à `master`.
+**Tu ne fusionnes jamais. Tu réécris.**
+
+La maquette est une référence visuelle, pas du code de production : elle a des
+constantes en dur, des figures pré-calculées, un `charte.js` de brouillon. Le
+site, lui, lit le contrat de vue et construit ses figures à l'exécution.
+Ressembler n'est pas copier.
+
+## Mise en place
+
+Les deux arbres côte à côte, un seul dépôt :
+
+```bash
+git worktree add ../election-maquette maquette
+```
+
+Tu lis `../election-maquette/maquette/`, tu écris dans le dépôt courant, sur
+une branche `interface/…`.
+
+## Ce que tu transposes
+
+1. **La palette et la typographie** → variables CSS dans
+   `scrutin/static/scrutin/style.css`. Les valeurs sortent du `:root` de la
+   variante retenue et de son objet `THEME`.
+2. **Les réglages Plotly** (`maquette/charte.js`) → `scrutin/charte.py` :
+   mêmes clés, mêmes valeurs, un template partagé appliqué à *tous* les
+   graphes.
+3. **La structure** → `templates/base.html` et `templates/home.html` : mêmes
+   blocs, mêmes classes, mais les constantes de la maquette remplacées par les
+   champs du contrat de vue.
+4. **Les gains techniques** trouvés en maquette : GeoJSON allégé et sorti des
+   figures, `plotly.min.js` vendoré à la bonne version, fond de carte vide si
+   la carte SVG est retenue.
+
+## Frontières
+
+- **Zone Interface uniquement** : `templates/`, `*/static/`, `charte.py`,
+  `graphiques.py`, `carte/`. Jamais `extrapolation.py`, `donnees.py`,
+  `models.py`, `pca/`, les migrations, `settings.py`, les imports.
+- **Jamais de `git merge maquette`**, ni de *cherry-pick* depuis cette
+  branche. Elle n'a aucune autorité sur `master`.
+- **Rien qui ne soit pas dans le contrat de vue.** Si la variante affiche une
+  donnée que le contrat ne porte pas, tu ne vas pas la chercher dans l'ORM :
+  tu la demandes à la voie `moteur`, et le contrat plus son test sont mis à
+  jour des deux côtés.
+- Une **figure** que le site ne produit pas encore s'ajoute à `graphiques.py`
+  ou `carte/` — jamais un JSON écrit à la main.
+
+## Vérifie ton rendu
+
+Tu produis du visuel : tu regardes avant de conclure.
+
+```bash
+python manage.py peupler_demo && python manage.py runserver
+```
+
+Le site d'un côté, la variante de l'autre, à **1200 px et à 400 px**. Les
+figures sortent du même code : seule la mise en page peut diverger. Une
+différence que tu ne sais pas expliquer est un bug, pas un détail.
+
+`ruff check .` et `pytest` avant de proposer quoi que ce soit.
+
+## Contexte
+
+`PLAN_MODERNISATION.md` Partie 7 — en particulier 7.0 (pourquoi deux branches)
+et 7.4 (ce passage). La maquette porte son propre `README.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,16 @@ media/
 .pytest_cache/
 .ruff_cache/
 
+# Le chantier de maquette vit sur la branche `maquette`, jamais dans master
+# (PLAN_MODERNISATION.md, Partie 7.0). Ses fichiers *générés* sont listés ici
+# aussi : un aller-retour entre les deux branches les laisse dans l'arbre de
+# travail, et un `git add -A` distrait les ferait entrer dans master. Ignorer
+# le dossier entier serait pire — la règle reviendrait dans la branche
+# `maquette` à la première resynchronisation et y masquerait les sources.
+maquette/figures.js
+maquette/plotly.min.js
+maquette/communes-simplifie.geojson
+
 # Artefacts
 cache.pickle
 votation_matrix.csv

--- a/.gitignore
+++ b/.gitignore
@@ -22,16 +22,6 @@ media/
 .pytest_cache/
 .ruff_cache/
 
-# Le chantier de maquette vit sur la branche `maquette`, jamais dans master
-# (PLAN_MODERNISATION.md, Partie 7.0). Ses fichiers *générés* sont listés ici
-# aussi : un aller-retour entre les deux branches les laisse dans l'arbre de
-# travail, et un `git add -A` distrait les ferait entrer dans master. Ignorer
-# le dossier entier serait pire — la règle reviendrait dans la branche
-# `maquette` à la première resynchronisation et y masquerait les sources.
-maquette/figures.js
-maquette/plotly.min.js
-maquette/communes-simplifie.geojson
-
 # Artefacts
 cache.pickle
 votation_matrix.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,8 @@ sauvegarde = copie du fichier). Pas de Postgres, pas de `psycopg`.
 ### Deux agents en parallèle
 
 Les deux voies existent aussi comme **agents Claude**, définis dans
-`.claude/agents/` : `moteur` et `interface`. Chacun a la liste de ses fichiers,
+`.claude/agents/` : `moteur` et `interface` — plus `passeur`, qui fait
+traverser le design de la branche `maquette` (voir plus bas). Chacun a la liste de ses fichiers,
 ses frontières explicites, et l'interdiction de toucher la zone de l'autre.
 
 - **Un agent par voie, un clone (ou un worktree) par agent.** Deux agents dans le
@@ -302,14 +303,21 @@ ses frontières explicites, et l'interdiction de toucher la zone de l'autre.
 
 Détail complet et découpage des tâches par voie : [`PLAN_MODERNISATION.md`](PLAN_MODERNISATION.md) Partie 0.
 
-### Refonte graphique : la maquette d'abord
+### Refonte graphique : la maquette d'abord, sur sa propre branche
 
-Le design ne part pas d'une charte abstraite : on itère sur une **page HTML
-statique** dans `maquette/` (voie I), qui embarque les **vraies figures
-Plotly en JSON** — produites par les mêmes fonctions que le site, jamais
-dessinées à la main — et un bloc de réglages `charte.js`. Une fois une
-variante validée à deux, la charte CSS et `charte.py` en sont *extraites*,
-puis transposées dans les gabarits Django. Détail : Partie 7 du plan.
+Le design ne part pas d'une charte abstraite : on itère sur des **pages HTML
+statiques** qui embarquent les **vraies figures Plotly en JSON** — produites
+par les mêmes fonctions que le site, jamais dessinées à la main — et un bloc
+de réglages `charte.js`. Une fois une variante retenue, la charte CSS et
+`charte.py` en sont *extraites*, puis transposées dans les gabarits Django.
+
+Tout ce chantier vit sur la branche **`maquette`**, qui n'est **jamais
+fusionnée dans `master`** : c'est un travail de conception, utile une fois,
+qui encombrerait la branche principale pour des années. La synchronisation va
+dans un seul sens, `master` → `maquette`. Le passage en production est une
+**réécriture**, confiée à un troisième agent, `passeur`, seul à lire les deux
+branches. Détail : Partie 7 du plan (7.0 pour les branches, 7.4 pour le
+passage).
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,15 @@ ses frontières explicites, et l'interdiction de toucher la zone de l'autre.
 
 Détail complet et découpage des tâches par voie : [`PLAN_MODERNISATION.md`](PLAN_MODERNISATION.md) Partie 0.
 
+### Refonte graphique : la maquette d'abord
+
+Le design ne part pas d'une charte abstraite : on itère sur une **page HTML
+statique** dans `maquette/` (voie I), qui embarque les **vraies figures
+Plotly en JSON** — produites par les mêmes fonctions que le site, jamais
+dessinées à la main — et un bloc de réglages `charte.js`. Une fois une
+variante validée à deux, la charte CSS et `charte.py` en sont *extraites*,
+puis transposées dans les gabarits Django. Détail : Partie 7 du plan.
+
 ## Conventions
 
 Domaine et modèles en **français** (`Commune`, `SujetVote`, `ResultatCommunalHistorique`, `nombre_oui`,

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -176,6 +176,15 @@ ses frontières — un agent refuse d'éditer la zone de l'autre.
 Découpage identique pour deux personnes ou deux agents — c'est le même contrat
 qui protège dans les deux cas.
 
+### Un troisième agent : le passeur
+
+`moteur` et `interface` travaillent chacun dans `master`. Le design, lui, se
+fait sur la branche `maquette` (Partie 7.0), et il faut bien que quelqu'un
+fasse traverser le résultat. C'est le rôle de l'agent **`passeur`**
+(`.claude/agents/passeur.md`) : il lit la branche `maquette`, écrit dans
+`master`, et **réécrit** — il ne fusionne jamais. C'est le seul agent qui voit
+les deux côtés, d'où des frontières écrites noir sur blanc.
+
 ### Rythme et intégration
 
 - Chacun son clone, chacun sa branche, **petites PR relues par l'autre** (c'est
@@ -580,8 +589,8 @@ Généraliser du binaire oui/non au multi-candidats :
 |---|---|---|
 | **0. Contrat** *(à deux, en premier)* | forme du dict + couture `donnees`/`graphiques` | idem |
 | **1. Le repo démarre** | A1–A3 + `peupler_demo` — **débloque la voie I** | (attend le jalon 1) |
-| **2. Base saine** | A4–A5 : bugs, tests, CI | P7.1–7.2 : maquette statique (figures Plotly en JSON), itérations |
-| **3. Prêt pour un scrutin** | B1–B4 : Django 5.2, dé-harcodage, pipeline | P7.3–7.4 : charte extraite de la maquette, transposition Django |
+| **2. Base saine** | A4–A5 : bugs, tests, CI | P7.0–7.2 : branche `maquette`, cinq variantes, itérations |
+| **3. Prêt pour un scrutin** | B1–B4 : Django 5.2, dé-harcodage, pipeline | P7.3–7.4 : charte extraite, passage en production |
 | **4. Communes à jour** | B4 : `importer_historique` depuis STAT-TAB | GeoJSON 2026, contrôle qualité |
 | **5. En production** | C1–C2 : Compose, cache, timer systemd | C3 : contrôle visuel du dry run |
 | **6. Produit** | D1 : IC bootstrap, données de convergence | D1 : réel/estimé, courbe, page Méthodes |
@@ -619,10 +628,11 @@ extrapolation qui tourne, site consultable. La conteneurisation peut suivre.
 6. Tests de `extrapolation.py` + CI.
 
 *Puis voie I* (Partie 7, dans cet ordre) :
-1. Figures exportables + `maquette/figures.js` + plotly.js vendoré (7.1).
-2. Maquette HTML statique, variantes d'agencement, itérations à deux (7.2).
+1. ~~Figures exportables, `figures.js`, plotly.js vendoré~~ (7.1, fait sur la
+   branche `maquette`).
+2. Choisir parmi les cinq variantes, itérer à deux, trancher Mapbox ou SVG (7.2).
 3. Charte CSS et `charte.py` extraites de la variante retenue (7.3), puis
-   transposition dans les gabarits Django (7.4).
+   passage en production par l'agent `passeur` (7.4).
 
 ---
 
@@ -699,8 +709,8 @@ largeur ou vit-elle à côté de l'histogramme, que voit-on sur un téléphone �
 extrait la charte**, et non l'inverse.
 
 Ce n'est **pas un mode maquette du site** (Partie 0 : un seul chemin de code) :
-c'est un dossier `maquette/` **[I]**, un fichier HTML qu'on ouvre en `file://`,
-qui vit à côté de Django et ne s'exécute jamais en production.
+ce sont des fichiers HTML qu'on ouvre en `file://`, sur une **branche à part**
+(7.0), qui ne s'exécutent jamais en production et ne sont jamais fusionnés.
 
 **Les figures Plotly y sont embarquées telles quelles, pas en image.** Une
 carte Plotly est un JSON (données + GeoJSON + layout) plus un appel à
@@ -710,58 +720,115 @@ couleurs, bornes, opacité, marges, survol, barre d'outils. Un PNG ou un SVG
 figerait justement ce qu'on veut faire varier. Le PNG ne sert qu'à discuter
 d'une variante par message.
 
-#### 7.1 Extraire les figures **[I]**, un export **[M]**
+#### 7.0 Où vit la maquette : une branche, pas `master` **[2]** — *décidé le 2026-09-10*
 
-- [ ] **[M]** `manage.py exporter_vue_accueil [sortie]` : écrit le contrat de
-      vue (`construire_vue_accueil()`) en JSON. Cinq lignes — le dict est déjà
-      sérialisable (`test_contrat`). Sur la base fictive :
-      `maquette/vue.json`.
-- [ ] **[I]** `graphiques.py` et `carte/API.py` renvoient une **figure**
-      (`go.Figure`) ; l'enrobage en `<div>` devient une fonction à part. Le
-      site n'y voit rien, mais la figure est alors exportable.
-- [ ] **[I]** `maquette/construire.py` : lit `vue.json`, appelle **les mêmes
-      fonctions que le site**, et écrit `maquette/figures.js`
-      (`window.FIGURES = {histogramme: …, cartes: {id: …}}` via
-      `fig.to_json()`). Un `<script src>` local marche en `file://`, un
-      `fetch` non — d'où du JS et pas du JSON.
-- [ ] **[I]** `maquette/plotly.min.js` copié depuis le paquet Python
-      (`plotly/package_data/`). *Constat au passage* : `base.html` charge
-      plotly.js **2.11 (2022) depuis le CDN** alors que le Python est en
-      Plotly 6, qui émet du plotly.js 3 — une figure jugée bonne en maquette
-      pourrait casser dans Django. Le vendorage prévu en « Hygiène » règle les
-      deux problèmes ; il remonte ici.
-- [ ] **[I]** GeoJSON communal **simplifié** pour la maquette (1,6 Mo recopié
-      dans chaque carte → trois objets = 5 Mo de HTML). Un facteur 5 à 10 sur
-      les contours ne se voit pas à l'échelle du pays, et le site en profitera
-      aussi (la page d'accueil pèse aujourd'hui autant que le GeoJSON × objets).
+Le générateur de maquette et les variantes **ne sont pas fusionnés dans
+`master`**. C'est un chantier de conception, utile une fois : le laisser dans
+la branche principale l'encombrerait pour des années — un dossier que plus
+personne n'ouvre, des dépendances de rendu, un `.gitignore` qui grossit, et un
+générateur qu'il faudra maintenir en état de marche à chaque changement de
+modèle.
 
-#### 7.2 La maquette, et les itérations **[2]**
+| | `master` | branche `maquette` |
+|---|---|---|
+| Contenu | le site, et **ce plan** | `maquette/` : générateur, `charte.js`, variantes, capture, allègement du GeoJSON |
+| Y reçoit aussi | la transposition du design retenu (7.4) | le petit refactor des fonctions de figures qui rend la maquette possible |
+| Durée de vie | permanente | tant que le design bouge |
 
-- [ ] **[I]** `maquette/accueil.html` : la page d'accueil, avec les champs du
-      contrat de vue en dur (date, avance, par objet : nom, % connu,
-      % extrapolé) et les figures de `figures.js`. **Deux ou trois variantes
-      d'agencement** (`accueil-a.html`, `-b.html`…) plutôt qu'une seule :
-      on compare, on ne devine pas.
-- [ ] **[I]** `maquette/charte.js` : **un seul bloc de réglages de design**
-      (couleurs, échelle de carte ancrée à 50 %, marges, fonte, survol,
-      modebar), appliqué **par-dessus** le JSON des figures au moment du
-      `newPlot`. Changer l'apparence = changer une valeur ici et recharger ;
-      on ne touche jamais aux données. Ce fichier est le brouillon de
-      `charte.py`.
-- [ ] **[2]** Itérations à deux sur le HTML — Claude Design ou à la main,
-      peu importe — **y compris la largeur téléphone**. Ce qu'on regarde à
-      chaque tour : le chiffre héro se lit-il d'un coup d'œil ? la ligne des
-      50 % est-elle là ? la carte dit-elle « penche oui / penche non » sans
-      légende ? ça tient-il en une hauteur d'écran ?
-- [ ] **[2]** Faire figurer dans la maquette **un graphe réellement produit
-      par Plotly**, pas un dessin de ce qu'on aimerait : c'est le point de
-      départ 7.1, et la garantie qu'on ne se promet pas un rendu que Plotly ne
-      donnera pas. Si un choix de design exige autre chose que Plotly, on le
-      décide là, en connaissance de cause.
+Deux règles :
+
+- **La branche `maquette` n'est jamais fusionnée dans `master`.** Aucune PR,
+  aucun *fast-forward*. Ce qui remonte est **réécrit** dans les gabarits
+  Django (7.4), pas transporté.
+- **La synchronisation va dans un seul sens : `master` → `maquette`**,
+  régulièrement, pour que la maquette continue de se construire sur le code
+  courant.
+
+Coût assumé : la maquette touche `graphiques.py` et `carte/API.py` (elle a
+besoin de la figure, pas du `<div>`). Un conflit est donc possible quand la
+voie I y travaille dans `master`. On garde cette empreinte sur le code de
+production **aussi petite que possible** — c'est le seul endroit où les deux
+branches se recouvrent.
+
+#### 7.1 Extraire les figures **[I]** — *fait (branche `maquette`)*
+
+Pas de commande d'export séparée : **on part de la sortie de Django**, mais de
+ses fonctions Python plutôt que de son HTML. `maquette/construire.py` amorce
+Django, appelle `construire_vue_accueil()` puis les mêmes fonctions de figures
+que les vues, et écrit le tout en JS. Récupérer la page rendue par
+`runserver` aurait aussi marché, mais chaque figure y est un bloc d'un
+mégaoctet au milieu du gabarit, avec ses réglages figés dans l'appel
+`Plotly.newPlot` : impossible d'itérer sur la mise en page sans naviguer dans
+ces blocs, ni d'appliquer `charte.js` sans réanalyser le HTML. Séparer les
+données (générées) de la page (écrite à la main) est tout l'intérêt.
+
+- [x] `graphiques.py` et `carte/API.py` exposent la **figure**
+      (`figure_histogramme`, `figure_carte`) ; `en_div` l'enrobe pour les
+      gabarits. Les vues n'ont pas changé.
+- [x] `construire.py` écrit `figures.js` (`window.VUE`, `FIGURES`, `GEOJSON`).
+      Un `<script src>` local marche en `file://`, un `fetch` non — d'où du JS
+      et pas du JSON.
+- [x] `plotly.min.js` copié depuis le paquet Python (Plotly 6.9 → plotly.js 3).
+      *Constat au passage* : `base.html` charge plotly.js **2.11 (2022) depuis
+      le CDN**. Une figure jugée bonne en maquette pourrait casser dans
+      Django. Le vendorage prévu en « Hygiène » règle les deux problèmes ; il
+      remonte en 7.4.
+- [x] **Poids divisé par six.** Plotly recopie le GeoJSON dans *chaque*
+      figure : il est désormais écrit une seule fois et rebranché au
+      chargement (6,0 → 1,8 Mo). Et `simplifier_geojson.py` allège les
+      contours — l'essentiel du gain vient de l'arrondi des coordonnées, qui
+      traînaient seize décimales, pas de Douglas-Peucker : le fichier de
+      l'OFS est déjà généralisé. **Le site gagnerait la même chose.**
+- [x] **`figure_carte_svg`** : la même carte en projection SVG
+      (`px.choropleth`), candidate au remplacement de `choropleth_mapbox`,
+      déprécié. Les deux variantes sont exportées, les maquettes les comparent.
+
+Ce que la comparaison a déjà donné, à verser au débat de 7.2 :
+
+| | Mapbox (aujourd'hui) | Projection SVG |
+|---|---|---|
+| WebGL | exigé | non |
+| Cadrage | zoom figé à la construction, à recalculer à chaque taille de cadre | `fitbounds` cadre tout seul |
+| Réseau | aucun (`white-bg`) | va chercher un fond de carte mondial sur le CDN, **sauf** si on lui en fournit un vide (`topojson-stub.js`) |
+| Interaction | zoom et déplacement à la souris | figée |
+| Impression, capture | aléatoire | fidèle |
+
+#### 7.2 Les variantes, et les itérations **[2]** — *en cours*
+
+- [x] **Cinq propositions**, sur les mêmes données et les mêmes figures : ce
+      qui les sépare est un choix, pas un hasard. Chacune porte son parti pris
+      en commentaire en tête ; `maquette/index.html` les liste.
+
+      | | Variante | Parti pris |
+      |---|---|---|
+      | **A** | La une | Un objet domine, comme un quotidien. Serif de titrage, filets, pas d'histogramme. |
+      | **B** | Tableau de bord | Aucun objet privilégié, tout en un écran. Dot plot dépouillé → projeté. |
+      | **C** | Cartes d'abord | Carte plein cadre, onglets, chiffre en surimpression. La seule en Mapbox. |
+      | **D** | Soirée électorale | Fond sombre, chiffres énormes, pour être projetée ou vue de loin. |
+      | **E** | Écart à la majorité | « À 3,1 points » plutôt que « 46,9 % ». La correction de l'extrapolation rendue visible. |
+
+- [x] `charte.js` : **un seul bloc de réglages de design**, surchargé par
+      variante. Changer l'apparence = changer une valeur et recharger ; on ne
+      touche jamais aux données. C'est le brouillon de `charte.py`.
+- [ ] **[2]** Itérations à deux, **y compris en largeur téléphone**. Ce qu'on
+      regarde à chaque tour : le chiffre héro se lit-il d'un coup d'œil ? la
+      ligne des 50 % est-elle là ? la carte dit-elle « penche oui / penche
+      non » sans légende ? ça tient-il en une hauteur d'écran ?
+- [ ] **[2]** Trancher **Mapbox ou SVG** (tableau en 7.1). Les deux sont sous
+      les yeux : C en Mapbox, les autres en SVG.
+- [ ] **[2]** Revalider la palette **sur fond sombre** si D est retenue : la
+      palette actuelle a été validée sur fond clair, les contrastes n'y sont
+      pas transposables.
 - [ ] **Critère d'arrêt** : une variante retenue, validée par les deux, sur
-      grand écran et sur téléphone, avec la palette validée ci-dessous ou une
-      palette **revalidée** par `validate_palette.js`. Tant que ce n'est pas
-      coché, rien de 7.3 ne commence.
+      grand écran et sur téléphone, avec une palette validée par
+      `validate_palette.js`. Tant que ce n'est pas coché, rien de 7.3 ne
+      commence.
+
+**Ce qu'une variante a le droit de demander.** E propose une figure que le
+site ne produit pas (l'axe centré sur la majorité). C'est légitime, et même le
+but : la maquette sert à découvrir ce qu'il faut construire. La figure sera
+alors **ajoutée à `graphiques.py`**, jamais bricolée dans `figures.js` ; une
+donnée absente du contrat de vue passe par la voie Moteur et son test.
 
 #### 7.3 Extraire la charte de la maquette **[I]**
 
@@ -775,24 +842,48 @@ d'une variante par message.
 - [ ] Mettre à jour la « Cible visuelle » ci-dessous avec ce qui a réellement
       été retenu (plutôt que de la laisser mentir).
 
-#### 7.4 Transposer dans Django **[I]**
+#### 7.4 Le passage de la maquette à la production **[2]**
 
-- [ ] `home.html` / `base.html` reproduisent la variante retenue : mêmes
-      blocs, mêmes classes, valeurs du contrat à la place des constantes.
-- [ ] Histogramme, carte, chiffre héro, tableaux de valeurs, hygiène — les
-      points de la cible visuelle, **dans l'ordre où la maquette les a
-      tranchés**.
-- [ ] **Contrôle** : `peupler_demo` + `runserver` à côté de `accueil.html`
-      dans le navigateur. Les deux doivent être indiscernables — les figures
-      sortent du même code, seule la mise en page peut diverger.
+C'est l'étape que la séparation en deux branches rend explicite : **on ne
+fusionne pas, on transpose.** La maquette est la référence visuelle ; le site
+est réécrit pour lui ressembler.
 
-#### 7.5 Vie de la maquette après coup
+Les deux arbres côte à côte, un seul dépôt :
 
-La maquette **reste** comme laboratoire de design : `construire.py` la
-régénère depuis la base fictive, avec les fonctions du site. Son seul risque
-est la dérive (une maquette qui promet ce que le site ne fait plus) ; le
-garde-fou est que ses figures **ne sont jamais écrites à la main** — elles
-viennent de `graphiques.py` et `carte/`, comme celles du site.
+```bash
+git worktree add ../election-maquette maquette
+```
+
+**Un agent `passeur`** (`.claude/agents/passeur.md`) est défini pour ce
+travail : il lit la branche `maquette` et écrit dans `master`, dans la seule
+zone Interface. C'est le seul agent qui voit les deux côtés — d'où des
+frontières écrites noir sur blanc.
+
+- [ ] Variables CSS de `style.css` = transcription de la variante retenue.
+- [ ] `scrutin/charte.py` = transcription de `charte.js` : mêmes clés, mêmes
+      valeurs, template Plotly partagé appliqué à *tous* les graphes.
+- [ ] `home.html` / `base.html` reproduisent la structure de la variante :
+      mêmes blocs, mêmes classes, valeurs du contrat à la place des constantes.
+- [ ] Ce que la variante réclamait de neuf est **demandé, pas contourné** :
+      figure ajoutée à `graphiques.py`, champ ajouté au contrat par la voie M.
+- [ ] Les gains techniques trouvés en maquette remontent ici : GeoJSON allégé,
+      GeoJSON sorti des figures, `plotly.min.js` vendoré à la bonne version,
+      et la carte SVG si elle est retenue (avec son fond de carte vide).
+- [ ] **Contrôle** : `peupler_demo` + `runserver` d'un côté, la variante de
+      l'autre, deux captures à 1200 et 400 px. Les figures sortent du même
+      code : seule la mise en page peut diverger.
+
+#### 7.5 Vie de la branche après coup
+
+La branche `maquette` **reste**, comme laboratoire : `construire.py` la
+régénère depuis la base fictive, avec les fonctions du site. On y remet
+`master` de temps en temps pour qu'elle continue de se construire.
+
+Son seul risque est la dérive — une maquette qui promet ce que le site ne fait
+plus. Deux garde-fous : ses figures ne sont jamais écrites à la main, et elle
+n'a aucune autorité sur `master` tant qu'un passage (7.4) n'a pas été relu.
+Le jour où le design se stabilise, la branche peut être abandonnée sans rien
+perdre : le site en porte le résultat.
 
 ### Cible visuelle (à confirmer par la maquette) **[I]**
 

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -44,7 +44,7 @@ forme du contrat (ci-dessous), méthode statistique, priorités. Seule la
 | `election/settings.py`, `Dockerfile`, `compose.yaml`, CI | **M** |
 | `carte/donnees.py` | **M** |
 | `templates/`, `*/static/` (CSS, JS, logo) | **I** |
-| `scrutin/charte.py`, `scrutin/graphiques.py`, `carte/figure.py` | **I** |
+| `scrutin/charte.py`, `scrutin/graphiques.py`, `carte/figure.py`, `maquette/` | **I** |
 | `*/views.py` | **commun** — doit rester minuscule (voir couture) |
 | `tests/test_contrat.py` | **commun** — fige la forme du contrat |
 | `CLAUDE.md`, `PLAN_MODERNISATION.md` | **commun** |
@@ -192,8 +192,8 @@ qui protège dans les deux cas.
 2. **Voie M seule** : A1–A3 + `peupler_demo` — au bout, `manage.py peupler_demo`
    puis `runserver` donnent un site complet depuis un clone frais. C'est le
    jalon qui débloque la voie I.
-3. **En parallèle** : voie M sur A4–A5 (bugs, tests), voie I sur la charte CSS
-   puis `charte.py`, histogramme, carte.
+3. **En parallèle** : voie M sur A4–A5 (bugs, tests), voie I sur la maquette
+   statique (Partie 7.1–7.2), dont la charte sera extraite ensuite.
 
 ---
 
@@ -580,8 +580,8 @@ Généraliser du binaire oui/non au multi-candidats :
 |---|---|---|
 | **0. Contrat** *(à deux, en premier)* | forme du dict + couture `donnees`/`graphiques` | idem |
 | **1. Le repo démarre** | A1–A3 + `peupler_demo` — **débloque la voie I** | (attend le jalon 1) |
-| **2. Base saine** | A4–A5 : bugs, tests, CI | P7 : charte CSS, `charte.py`, histogramme, carte |
-| **3. Prêt pour un scrutin** | B1–B4 : Django 5.2, dé-harcodage, pipeline | P7 : chiffre héro, a11y, hygiène |
+| **2. Base saine** | A4–A5 : bugs, tests, CI | P7.1–7.2 : maquette statique (figures Plotly en JSON), itérations |
+| **3. Prêt pour un scrutin** | B1–B4 : Django 5.2, dé-harcodage, pipeline | P7.3–7.4 : charte extraite de la maquette, transposition Django |
 | **4. Communes à jour** | B4 : `importer_historique` depuis STAT-TAB | GeoJSON 2026, contrôle qualité |
 | **5. En production** | C1–C2 : Compose, cache, timer systemd | C3 : contrôle visuel du dry run |
 | **6. Produit** | D1 : IC bootstrap, données de convergence | D1 : réel/estimé, courbe, page Méthodes |
@@ -618,11 +618,11 @@ extrapolation qui tourne, site consultable. La conteneurisation peut suivre.
 5. Corrections des bugs latents (petites PR séparées).
 6. Tests de `extrapolation.py` + CI.
 
-*Puis voie I* :
-1. Charte en variables CSS + fonte unique + contrastes corrigés.
-2. `charte.py` (template Plotly partagé), puis histogramme (ligne des 50 %),
-   puis carte (divergente ancrée à 50 %).
-3. Chiffre héro, tableaux de valeurs, hygiène (SVG, favicon, Plotly vendoré).
+*Puis voie I* (Partie 7, dans cet ordre) :
+1. Figures exportables + `maquette/figures.js` + plotly.js vendoré (7.1).
+2. Maquette HTML statique, variantes d'agencement, itérations à deux (7.2).
+3. Charte CSS et `charte.py` extraites de la variante retenue (7.3), puis
+   transposition dans les gabarits Django (7.4).
 
 ---
 
@@ -687,7 +687,118 @@ au backend. Alimente D1.
 - Bon point à préserver : `white-bg` sans tuiles externes → compatible avec le
   mirroir statique, aucune dépendance à un serveur de cartes.
 
-### Refonte proposée **[I]**
+### Démarche retenue : la maquette d'abord **[2]** — *décidé le 2026-09-10*
+
+La liste ci-dessous (« Cible visuelle ») a été écrite **sans jamais voir une
+page** : des codes hexa, une fonte, une échelle de carte. Or les vrais
+arbitrages de ce site sont des questions de mise en page — où va le chiffre
+héro, combien d'objets tiennent côte à côte, la carte prend-elle toute la
+largeur ou vit-elle à côté de l'histogramme, que voit-on sur un téléphone à
+18 h le dimanche. Ça ne se tranche qu'en regardant. On inverse donc l'ordre :
+**on itère sur une page HTML statique jusqu'à être contents, puis on en
+extrait la charte**, et non l'inverse.
+
+Ce n'est **pas un mode maquette du site** (Partie 0 : un seul chemin de code) :
+c'est un dossier `maquette/` **[I]**, un fichier HTML qu'on ouvre en `file://`,
+qui vit à côté de Django et ne s'exécute jamais en production.
+
+**Les figures Plotly y sont embarquées telles quelles, pas en image.** Une
+carte Plotly est un JSON (données + GeoJSON + layout) plus un appel à
+`Plotly.newPlot` : collé dans la page statique, elle reste interactive
+(survol, zoom) et **tout son look and feel est éditable en clair** — échelle de
+couleurs, bornes, opacité, marges, survol, barre d'outils. Un PNG ou un SVG
+figerait justement ce qu'on veut faire varier. Le PNG ne sert qu'à discuter
+d'une variante par message.
+
+#### 7.1 Extraire les figures **[I]**, un export **[M]**
+
+- [ ] **[M]** `manage.py exporter_vue_accueil [sortie]` : écrit le contrat de
+      vue (`construire_vue_accueil()`) en JSON. Cinq lignes — le dict est déjà
+      sérialisable (`test_contrat`). Sur la base fictive :
+      `maquette/vue.json`.
+- [ ] **[I]** `graphiques.py` et `carte/API.py` renvoient une **figure**
+      (`go.Figure`) ; l'enrobage en `<div>` devient une fonction à part. Le
+      site n'y voit rien, mais la figure est alors exportable.
+- [ ] **[I]** `maquette/construire.py` : lit `vue.json`, appelle **les mêmes
+      fonctions que le site**, et écrit `maquette/figures.js`
+      (`window.FIGURES = {histogramme: …, cartes: {id: …}}` via
+      `fig.to_json()`). Un `<script src>` local marche en `file://`, un
+      `fetch` non — d'où du JS et pas du JSON.
+- [ ] **[I]** `maquette/plotly.min.js` copié depuis le paquet Python
+      (`plotly/package_data/`). *Constat au passage* : `base.html` charge
+      plotly.js **2.11 (2022) depuis le CDN** alors que le Python est en
+      Plotly 6, qui émet du plotly.js 3 — une figure jugée bonne en maquette
+      pourrait casser dans Django. Le vendorage prévu en « Hygiène » règle les
+      deux problèmes ; il remonte ici.
+- [ ] **[I]** GeoJSON communal **simplifié** pour la maquette (1,6 Mo recopié
+      dans chaque carte → trois objets = 5 Mo de HTML). Un facteur 5 à 10 sur
+      les contours ne se voit pas à l'échelle du pays, et le site en profitera
+      aussi (la page d'accueil pèse aujourd'hui autant que le GeoJSON × objets).
+
+#### 7.2 La maquette, et les itérations **[2]**
+
+- [ ] **[I]** `maquette/accueil.html` : la page d'accueil, avec les champs du
+      contrat de vue en dur (date, avance, par objet : nom, % connu,
+      % extrapolé) et les figures de `figures.js`. **Deux ou trois variantes
+      d'agencement** (`accueil-a.html`, `-b.html`…) plutôt qu'une seule :
+      on compare, on ne devine pas.
+- [ ] **[I]** `maquette/charte.js` : **un seul bloc de réglages de design**
+      (couleurs, échelle de carte ancrée à 50 %, marges, fonte, survol,
+      modebar), appliqué **par-dessus** le JSON des figures au moment du
+      `newPlot`. Changer l'apparence = changer une valeur ici et recharger ;
+      on ne touche jamais aux données. Ce fichier est le brouillon de
+      `charte.py`.
+- [ ] **[2]** Itérations à deux sur le HTML — Claude Design ou à la main,
+      peu importe — **y compris la largeur téléphone**. Ce qu'on regarde à
+      chaque tour : le chiffre héro se lit-il d'un coup d'œil ? la ligne des
+      50 % est-elle là ? la carte dit-elle « penche oui / penche non » sans
+      légende ? ça tient-il en une hauteur d'écran ?
+- [ ] **[2]** Faire figurer dans la maquette **un graphe réellement produit
+      par Plotly**, pas un dessin de ce qu'on aimerait : c'est le point de
+      départ 7.1, et la garantie qu'on ne se promet pas un rendu que Plotly ne
+      donnera pas. Si un choix de design exige autre chose que Plotly, on le
+      décide là, en connaissance de cause.
+- [ ] **Critère d'arrêt** : une variante retenue, validée par les deux, sur
+      grand écran et sur téléphone, avec la palette validée ci-dessous ou une
+      palette **revalidée** par `validate_palette.js`. Tant que ce n'est pas
+      coché, rien de 7.3 ne commence.
+
+#### 7.3 Extraire la charte de la maquette **[I]**
+
+- [ ] Variables CSS de `style.css` = transcription de la maquette retenue
+      (`--surface`, `--encre-1/2`, `--bleu-450`…), une seule fonte.
+- [ ] `scrutin/charte.py` = transcription de `charte.js` : mêmes clés, mêmes
+      valeurs, template Plotly partagé appliqué à *tous* les graphes. Un test
+      compare les deux — ou `construire.py` régénère `charte.js` depuis
+      `charte.py`, et la maquette devient l'*aval* de la charte, plus son
+      brouillon.
+- [ ] Mettre à jour la « Cible visuelle » ci-dessous avec ce qui a réellement
+      été retenu (plutôt que de la laisser mentir).
+
+#### 7.4 Transposer dans Django **[I]**
+
+- [ ] `home.html` / `base.html` reproduisent la variante retenue : mêmes
+      blocs, mêmes classes, valeurs du contrat à la place des constantes.
+- [ ] Histogramme, carte, chiffre héro, tableaux de valeurs, hygiène — les
+      points de la cible visuelle, **dans l'ordre où la maquette les a
+      tranchés**.
+- [ ] **Contrôle** : `peupler_demo` + `runserver` à côté de `accueil.html`
+      dans le navigateur. Les deux doivent être indiscernables — les figures
+      sortent du même code, seule la mise en page peut diverger.
+
+#### 7.5 Vie de la maquette après coup
+
+La maquette **reste** comme laboratoire de design : `construire.py` la
+régénère depuis la base fictive, avec les fonctions du site. Son seul risque
+est la dérive (une maquette qui promet ce que le site ne fait plus) ; le
+garde-fou est que ses figures **ne sont jamais écrites à la main** — elles
+viennent de `graphiques.py` et `carte/`, comme celles du site.
+
+### Cible visuelle (à confirmer par la maquette) **[I]**
+
+Ce qui suit est l'hypothèse de départ de 7.2, **pas un cahier des charges** :
+la maquette peut l'infirmer, et 7.3 la réécrit avec ce qui a été retenu.
+
 1. **Mini-charte en variables CSS** (`--surface`, `--encre-1/2`, `--bleu-450`…,
    valeurs de la palette validée ci-dessous) ; **une seule fonte** : la sans
    système (`system-ui, …`) partout — Garamond peut survivre dans le seul
@@ -710,7 +821,8 @@ au backend. Alimente D1.
    sans-couleur + copiable), `lang="fr"`, alt/aria sur la nav.
 7. **Hygiène** : icône ☰ en SVG inline (supprimer Font Awesome), favicon,
    liens réparés, **vendorer `plotly.min.js`** (le CDN casse le mirroir wget
-   hors-ligne et fige la version), année du footer dynamique.
+   hors-ligne et fige la version — et voir 7.1 pour le décalage de version),
+   année du footer dynamique.
 
 Palettes validées (`validate_palette.js`, surface `#fcfcfb`) :
 - `#2a78d6` + `#eb6834` : tous contrôles PASS (ΔE daltonien 24,7 ; normal 33,6).

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -699,191 +699,108 @@ au backend. Alimente D1.
 
 ### Démarche retenue : la maquette d'abord **[2]** — *décidé le 2026-09-10*
 
-La liste ci-dessous (« Cible visuelle ») a été écrite **sans jamais voir une
-page** : des codes hexa, une fonte, une échelle de carte. Or les vrais
-arbitrages de ce site sont des questions de mise en page — où va le chiffre
-héro, combien d'objets tiennent côte à côte, la carte prend-elle toute la
-largeur ou vit-elle à côté de l'histogramme, que voit-on sur un téléphone à
-18 h le dimanche. Ça ne se tranche qu'en regardant. On inverse donc l'ordre :
-**on itère sur une page HTML statique jusqu'à être contents, puis on en
-extrait la charte**, et non l'inverse.
+La « Cible visuelle » ci-dessous a été écrite sans jamais voir une page. Or ce
+qui se décide ici est une question de mise en page — où va le chiffre héro, ce
+qu'on voit sur un téléphone à 18 h le dimanche — et ça ne se tranche qu'en
+regardant. On inverse donc l'ordre : **on itère sur des pages HTML statiques,
+puis on en extrait la charte.**
 
-Ce n'est **pas un mode maquette du site** (Partie 0 : un seul chemin de code) :
-ce sont des fichiers HTML qu'on ouvre en `file://`, sur une **branche à part**
-(7.0), qui ne s'exécutent jamais en production et ne sont jamais fusionnés.
+Les figures Plotly y sont embarquées **en JSON, pas en image** : la carte reste
+interactive et tout son rendu est éditable en clair, là où un PNG figerait
+justement ce qu'on veut faire varier.
 
-**Les figures Plotly y sont embarquées telles quelles, pas en image.** Une
-carte Plotly est un JSON (données + GeoJSON + layout) plus un appel à
-`Plotly.newPlot` : collé dans la page statique, elle reste interactive
-(survol, zoom) et **tout son look and feel est éditable en clair** — échelle de
-couleurs, bornes, opacité, marges, survol, barre d'outils. Un PNG ou un SVG
-figerait justement ce qu'on veut faire varier. Le PNG ne sert qu'à discuter
-d'une variante par message.
+#### 7.0 La maquette vit sur une branche, pas dans `master` **[2]**
 
-#### 7.0 Où vit la maquette : une branche, pas `master` **[2]** — *décidé le 2026-09-10*
+Chantier utile une fois : dans la branche principale, il l'encombrerait pour
+des années.
 
-Le générateur de maquette et les variantes **ne sont pas fusionnés dans
-`master`**. C'est un chantier de conception, utile une fois : le laisser dans
-la branche principale l'encombrerait pour des années — un dossier que plus
-personne n'ouvre, des dépendances de rendu, un `.gitignore` qui grossit, et un
-générateur qu'il faudra maintenir en état de marche à chaque changement de
-modèle.
+- **La branche `maquette` n'est jamais fusionnée.** Ce qui remonte est
+  **réécrit** dans les gabarits Django (7.4), pas transporté.
+- **Synchronisation à sens unique**, `master` → `maquette`, pour qu'elle
+  continue de se construire.
+- Coût assumé : elle touche `graphiques.py` et `carte/API.py` (elle a besoin de
+  la figure, pas du `<div>`) — seul recouvrement entre les deux branches, à
+  garder minimal.
 
-| | `master` | branche `maquette` |
-|---|---|---|
-| Contenu | le site, et **ce plan** | `maquette/` : générateur, `charte.js`, variantes, capture, allègement du GeoJSON |
-| Y reçoit aussi | la transposition du design retenu (7.4) | le petit refactor des fonctions de figures qui rend la maquette possible |
-| Durée de vie | permanente | tant que le design bouge |
+#### 7.1 Extraire les figures **[I]** — *fait*
 
-Deux règles :
+`maquette/construire.py` amorce Django et appelle **les mêmes fonctions de
+figures que les vues**, puis écrit `figures.js`. Partir du HTML rendu aurait
+marché aussi, mais chaque figure y est un bloc d'un mégaoctet aux réglages
+figés : séparer les données (générées) de la page (écrite à la main) est tout
+l'intérêt.
 
-- **La branche `maquette` n'est jamais fusionnée dans `master`.** Aucune PR,
-  aucun *fast-forward*. Ce qui remonte est **réécrit** dans les gabarits
-  Django (7.4), pas transporté.
-- **La synchronisation va dans un seul sens : `master` → `maquette`**,
-  régulièrement, pour que la maquette continue de se construire sur le code
-  courant.
+- [x] `graphiques.py` et `carte/API.py` exposent la figure ; `en_div` l'enrobe
+      pour les gabarits. Les vues n'ont pas changé.
+- [x] **Poids divisé par six** (6,0 → 1,8 Mo) : le GeoJSON n'est plus recopié
+      dans chaque figure, et ses coordonnées ne traînent plus seize décimales.
+      **Le site gagnerait la même chose.**
+- [x] `plotly.min.js` copié du paquet Python. *Au passage* : `base.html` charge
+      la version **2.11 (2022)** depuis le CDN alors que le Python produit du
+      plotly.js 3. Le vendorage remonte en 7.4.
+- [x] `figure_carte_svg`, candidate au remplacement de `choropleth_mapbox`,
+      déprécié. Les deux sont exportées, les maquettes les comparent :
 
-Coût assumé : la maquette touche `graphiques.py` et `carte/API.py` (elle a
-besoin de la figure, pas du `<div>`). Un conflit est donc possible quand la
-voie I y travaille dans `master`. On garde cette empreinte sur le code de
-production **aussi petite que possible** — c'est le seul endroit où les deux
-branches se recouvrent.
-
-#### 7.1 Extraire les figures **[I]** — *fait (branche `maquette`)*
-
-Pas de commande d'export séparée : **on part de la sortie de Django**, mais de
-ses fonctions Python plutôt que de son HTML. `maquette/construire.py` amorce
-Django, appelle `construire_vue_accueil()` puis les mêmes fonctions de figures
-que les vues, et écrit le tout en JS. Récupérer la page rendue par
-`runserver` aurait aussi marché, mais chaque figure y est un bloc d'un
-mégaoctet au milieu du gabarit, avec ses réglages figés dans l'appel
-`Plotly.newPlot` : impossible d'itérer sur la mise en page sans naviguer dans
-ces blocs, ni d'appliquer `charte.js` sans réanalyser le HTML. Séparer les
-données (générées) de la page (écrite à la main) est tout l'intérêt.
-
-- [x] `graphiques.py` et `carte/API.py` exposent la **figure**
-      (`figure_histogramme`, `figure_carte`) ; `en_div` l'enrobe pour les
-      gabarits. Les vues n'ont pas changé.
-- [x] `construire.py` écrit `figures.js` (`window.VUE`, `FIGURES`, `GEOJSON`).
-      Un `<script src>` local marche en `file://`, un `fetch` non — d'où du JS
-      et pas du JSON.
-- [x] `plotly.min.js` copié depuis le paquet Python (Plotly 6.9 → plotly.js 3).
-      *Constat au passage* : `base.html` charge plotly.js **2.11 (2022) depuis
-      le CDN**. Une figure jugée bonne en maquette pourrait casser dans
-      Django. Le vendorage prévu en « Hygiène » règle les deux problèmes ; il
-      remonte en 7.4.
-- [x] **Poids divisé par six.** Plotly recopie le GeoJSON dans *chaque*
-      figure : il est désormais écrit une seule fois et rebranché au
-      chargement (6,0 → 1,8 Mo). Et `simplifier_geojson.py` allège les
-      contours — l'essentiel du gain vient de l'arrondi des coordonnées, qui
-      traînaient seize décimales, pas de Douglas-Peucker : le fichier de
-      l'OFS est déjà généralisé. **Le site gagnerait la même chose.**
-- [x] **`figure_carte_svg`** : la même carte en projection SVG
-      (`px.choropleth`), candidate au remplacement de `choropleth_mapbox`,
-      déprécié. Les deux variantes sont exportées, les maquettes les comparent.
-
-Ce que la comparaison a déjà donné, à verser au débat de 7.2 :
-
-| | Mapbox (aujourd'hui) | Projection SVG |
+| | Mapbox | Projection SVG |
 |---|---|---|
 | WebGL | exigé | non |
-| Cadrage | zoom figé à la construction, à recalculer à chaque taille de cadre | `fitbounds` cadre tout seul |
-| Réseau | aucun (`white-bg`) | va chercher un fond de carte mondial sur le CDN, **sauf** si on lui en fournit un vide (`topojson-stub.js`) |
-| Interaction | zoom et déplacement à la souris | figée |
+| Cadrage | zoom figé, à recalculer | `fitbounds`, automatique |
+| Réseau | aucun | un fond de carte mondial, sauf à lui en fournir un vide |
+| Zoom à la souris | oui | non |
 | Impression, capture | aléatoire | fidèle |
 
-#### 7.2 Les variantes, et les itérations **[2]** — *en cours*
+#### 7.2 Les variantes **[2]** — *en cours*
 
-- [x] **Cinq propositions**, sur les mêmes données et les mêmes figures : ce
-      qui les sépare est un choix, pas un hasard. Chacune porte son parti pris
-      en commentaire en tête ; `maquette/index.html` les liste.
+Cinq propositions sur les mêmes données et les mêmes figures : ce qui les
+sépare est un choix, pas un hasard. `maquette/index.html` les liste, `charte.js`
+porte leurs réglages.
 
-      | | Variante | Parti pris |
-      |---|---|---|
-      | **A** | La une | Un objet domine, comme un quotidien. Serif de titrage, filets, pas d'histogramme. |
-      | **B** | Tableau de bord | Aucun objet privilégié, tout en un écran. Dot plot dépouillé → projeté. |
-      | **C** | Cartes d'abord | Carte plein cadre, onglets, chiffre en surimpression. La seule en Mapbox. |
-      | **D** | Soirée électorale | Fond sombre, chiffres énormes, pour être projetée ou vue de loin. |
-      | **E** | Écart à la majorité | « À 3,1 points » plutôt que « 46,9 % ». La correction de l'extrapolation rendue visible. |
+| | Variante | Parti pris |
+|---|---|---|
+| **A** | La une | Un objet domine, comme un quotidien. Serif de titrage, pas d'histogramme. |
+| **B** | Tableau de bord | Aucun objet privilégié, tout en un écran. Dot plot dépouillé → projeté. |
+| **C** | Cartes d'abord | Carte plein cadre, onglets, chiffre en surimpression. La seule en Mapbox. |
+| **D** | Soirée électorale | Fond sombre, chiffres énormes, pour être projetée ou vue de loin. |
+| **E** | Écart à la majorité | « À 3,1 points » plutôt que « 46,9 % ». La correction de l'extrapolation rendue visible. |
 
-- [x] `charte.js` : **un seul bloc de réglages de design**, surchargé par
-      variante. Changer l'apparence = changer une valeur et recharger ; on ne
-      touche jamais aux données. C'est le brouillon de `charte.py`.
-- [ ] **[2]** Itérations à deux, **y compris en largeur téléphone**. Ce qu'on
-      regarde à chaque tour : le chiffre héro se lit-il d'un coup d'œil ? la
-      ligne des 50 % est-elle là ? la carte dit-elle « penche oui / penche
-      non » sans légende ? ça tient-il en une hauteur d'écran ?
-- [ ] **[2]** Trancher **Mapbox ou SVG** (tableau en 7.1). Les deux sont sous
-      les yeux : C en Mapbox, les autres en SVG.
-- [ ] **[2]** Revalider la palette **sur fond sombre** si D est retenue : la
-      palette actuelle a été validée sur fond clair, les contrastes n'y sont
-      pas transposables.
-- [ ] **Critère d'arrêt** : une variante retenue, validée par les deux, sur
-      grand écran et sur téléphone, avec une palette validée par
-      `validate_palette.js`. Tant que ce n'est pas coché, rien de 7.3 ne
-      commence.
+- [ ] Itérer à deux, **largeur téléphone comprise**.
+- [ ] Trancher **Mapbox ou SVG** (tableau ci-dessus).
+- [ ] Revalider la palette **sur fond sombre** si D est retenue.
+- [ ] **Critère d'arrêt** : une variante validée par les deux, sur grand écran
+      et sur téléphone, palette passée à `validate_palette.js`. Rien de 7.3 ne
+      commence avant.
 
-**Ce qu'une variante a le droit de demander.** E propose une figure que le
-site ne produit pas (l'axe centré sur la majorité). C'est légitime, et même le
-but : la maquette sert à découvrir ce qu'il faut construire. La figure sera
-alors **ajoutée à `graphiques.py`**, jamais bricolée dans `figures.js` ; une
-donnée absente du contrat de vue passe par la voie Moteur et son test.
+Une variante a le droit de **demander** ce que le site ne fait pas — E propose
+une figure qui n'existe nulle part. Elle sera alors ajoutée à `graphiques.py`,
+jamais bricolée dans `figures.js` ; une donnée hors contrat passe par la voie M.
 
-#### 7.3 Extraire la charte de la maquette **[I]**
+#### 7.3 Extraire la charte **[I]**
 
-- [ ] Variables CSS de `style.css` = transcription de la maquette retenue
-      (`--surface`, `--encre-1/2`, `--bleu-450`…), une seule fonte.
-- [ ] `scrutin/charte.py` = transcription de `charte.js` : mêmes clés, mêmes
-      valeurs, template Plotly partagé appliqué à *tous* les graphes. Un test
-      compare les deux — ou `construire.py` régénère `charte.js` depuis
-      `charte.py`, et la maquette devient l'*aval* de la charte, plus son
-      brouillon.
-- [ ] Mettre à jour la « Cible visuelle » ci-dessous avec ce qui a réellement
-      été retenu (plutôt que de la laisser mentir).
+- [ ] `style.css` : les variables CSS de la variante retenue, une seule fonte.
+- [ ] `scrutin/charte.py` : transcription de `charte.js`, template Plotly
+      partagé appliqué à *tous* les graphes.
+- [ ] Réécrire la « Cible visuelle » avec ce qui a réellement été retenu.
 
-#### 7.4 Le passage de la maquette à la production **[2]**
+#### 7.4 Le passage en production **[2]**
 
-C'est l'étape que la séparation en deux branches rend explicite : **on ne
-fusionne pas, on transpose.** La maquette est la référence visuelle ; le site
-est réécrit pour lui ressembler.
+**On ne fusionne pas, on transpose.** `git worktree add ../election-maquette
+maquette` met les deux arbres côte à côte, et l'agent **`passeur`**
+(`.claude/agents/passeur.md`) fait le travail : seul à lire les deux branches,
+d'où des frontières écrites noir sur blanc.
 
-Les deux arbres côte à côte, un seul dépôt :
+- [ ] `base.html` / `home.html` reproduisent la structure de la variante, les
+      valeurs du contrat à la place des constantes.
+- [ ] Ce qu'elle réclamait de neuf est **demandé, pas contourné**.
+- [ ] Les gains techniques de 7.1 remontent ici, `plotly.min.js` vendoré compris.
+- [ ] **Contrôle** : le site et la variante côte à côte, à 1200 et 400 px. Les
+      figures sortent du même code, seule la mise en page peut diverger.
 
-```bash
-git worktree add ../election-maquette maquette
-```
+#### 7.5 Après coup
 
-**Un agent `passeur`** (`.claude/agents/passeur.md`) est défini pour ce
-travail : il lit la branche `maquette` et écrit dans `master`, dans la seule
-zone Interface. C'est le seul agent qui voit les deux côtés — d'où des
-frontières écrites noir sur blanc.
-
-- [ ] Variables CSS de `style.css` = transcription de la variante retenue.
-- [ ] `scrutin/charte.py` = transcription de `charte.js` : mêmes clés, mêmes
-      valeurs, template Plotly partagé appliqué à *tous* les graphes.
-- [ ] `home.html` / `base.html` reproduisent la structure de la variante :
-      mêmes blocs, mêmes classes, valeurs du contrat à la place des constantes.
-- [ ] Ce que la variante réclamait de neuf est **demandé, pas contourné** :
-      figure ajoutée à `graphiques.py`, champ ajouté au contrat par la voie M.
-- [ ] Les gains techniques trouvés en maquette remontent ici : GeoJSON allégé,
-      GeoJSON sorti des figures, `plotly.min.js` vendoré à la bonne version,
-      et la carte SVG si elle est retenue (avec son fond de carte vide).
-- [ ] **Contrôle** : `peupler_demo` + `runserver` d'un côté, la variante de
-      l'autre, deux captures à 1200 et 400 px. Les figures sortent du même
-      code : seule la mise en page peut diverger.
-
-#### 7.5 Vie de la branche après coup
-
-La branche `maquette` **reste**, comme laboratoire : `construire.py` la
-régénère depuis la base fictive, avec les fonctions du site. On y remet
-`master` de temps en temps pour qu'elle continue de se construire.
-
-Son seul risque est la dérive — une maquette qui promet ce que le site ne fait
-plus. Deux garde-fous : ses figures ne sont jamais écrites à la main, et elle
-n'a aucune autorité sur `master` tant qu'un passage (7.4) n'a pas été relu.
-Le jour où le design se stabilise, la branche peut être abandonnée sans rien
-perdre : le site en porte le résultat.
+La branche reste comme laboratoire, régénérée depuis la base fictive. Son seul
+risque est la dérive, tenu par deux garde-fous : ses figures ne sont jamais
+écrites à la main, et elle n'a aucune autorité sur `master`. Le jour où le
+design se stabilise, on peut l'abandonner sans rien perdre.
 
 ### Cible visuelle (à confirmer par la maquette) **[I]**
 


### PR DESCRIPTION
Document seul — aucun code de production touché. C'est la **seule** PR de ce chantier vers `master` : le reste vit sur la branche `maquette`, qui n'est jamais fusionnée.

## 1. Le design se fait en regardant, pas en décrivant

L'ancienne « Refonte proposée » de la Partie 7 a été écrite **sans jamais voir une page** : des codes hexa, une fonte, une échelle de carte. Or les vrais arbitrages de ce site sont des questions de mise en page — où va le chiffre héro, combien d'objets tiennent côte à côte, la carte prend-elle toute la largeur, que voit-on sur un téléphone à 18 h le dimanche.

La Partie 7 devient donc : on itère sur des pages HTML statiques jusqu'à être contents, **puis** on en extrait la charte. L'ancienne liste de choix visuels est conservée mais rétrogradée en « Cible visuelle (à confirmer par la maquette) ». Les palettes validées ne bougent pas.

## 2. Où vit la maquette (7.0)

**Pas dans `master`.** C'est un chantier de conception, utile une fois ; dans la branche principale il l'encombrerait pour des années — un dossier que plus personne n'ouvre, un générateur à maintenir à chaque changement de modèle.

| | `master` | branche `maquette` |
|---|---|---|
| Contenu | le site, et ce plan | générateur, `charte.js`, variantes, capture, allègement du GeoJSON |
| Y reçoit aussi | la transposition du design retenu (7.4) | le petit refactor des fonctions de figures qui la rend possible |
| Durée de vie | permanente | tant que le design bouge |

Deux règles : la branche n'est **jamais fusionnée** (ce qui remonte est réécrit, pas transporté), et la synchronisation va dans **un seul sens**, `master` → `maquette`. Le coût est nommé plutôt que caché : la maquette touche `graphiques.py` et `carte/API.py`, seul recouvrement entre les deux branches.

## 3. Le passage en production (7.4), et l'agent qui le fait

`git worktree add ../election-maquette maquette` met les deux arbres côte à côte. Un troisième agent, **`passeur`** (`.claude/agents/passeur.md`, ajouté ici), est défini pour ce travail : il lit la branche `maquette`, écrit dans `master`, et réécrit — il ne fusionne jamais.

Ses frontières sont explicites parce qu'il est le seul à voir les deux côtés : zone Interface uniquement, jamais de `git merge maquette`, rien qui ne soit pas dans le contrat de vue, une figure absente s'ajoute à `graphiques.py` plutôt que d'être bricolée, et contrôle visuel du site à côté de la variante à 1200 et 400 px.

## 4. Ce que la branche a déjà produit (rendu compte en 7.1 et 7.2)

- **Cinq variantes** de la page d'accueil à départager : « la une », « tableau de bord », « cartes d'abord », « soirée électorale », « écart à la majorité ».
- **Poids divisé par six** : Plotly recopiait le GeoJSON dans chaque figure, il est maintenant écrit une fois et rebranché au chargement. L'allègement des contours vient surtout de l'arrondi des coordonnées, qui traînaient seize décimales. **Le site gagnerait la même chose.**
- **Une carte SVG** candidate au remplacement de `choropleth_mapbox`, déprécié, avec un tableau de comparaison (WebGL, cadrage, réseau, interaction, impression) pour trancher en connaissance de cause.
- **Un décalage de version** : `base.html` charge plotly.js 2.11 (2022) depuis le CDN alors que le Python est en Plotly 6, qui émet du plotly.js 3.

## Vérifications

`ruff check .` passe. Les 55 tests passent (aucun code de production modifié ici).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RinRFrnqgn8D8D77URP1Nn