### PR TITLE
maquette: page statique régénérable, avec les figures Plotly du site en JSON (7.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ politiques/          # sortie de wget --recursive
 
 # Données de production montées dans le conteneur (base SQLite).
 /var/
+
+# Maquette statique : générés par maquette/construire.py
+maquette/figures.js
+maquette/plotly.min.js

--- a/PLAN_MODERNISATION.md
+++ b/PLAN_MODERNISATION.md
@@ -710,30 +710,44 @@ couleurs, bornes, opacité, marges, survol, barre d'outils. Un PNG ou un SVG
 figerait justement ce qu'on veut faire varier. Le PNG ne sert qu'à discuter
 d'une variante par message.
 
-#### 7.1 Extraire les figures **[I]**, un export **[M]**
+#### 7.1 Extraire les figures **[I]** — *fait le 2026-09-10*
 
-- [ ] **[M]** `manage.py exporter_vue_accueil [sortie]` : écrit le contrat de
-      vue (`construire_vue_accueil()`) en JSON. Cinq lignes — le dict est déjà
-      sérialisable (`test_contrat`). Sur la base fictive :
-      `maquette/vue.json`.
-- [ ] **[I]** `graphiques.py` et `carte/API.py` renvoient une **figure**
-      (`go.Figure`) ; l'enrobage en `<div>` devient une fonction à part. Le
-      site n'y voit rien, mais la figure est alors exportable.
-- [ ] **[I]** `maquette/construire.py` : lit `vue.json`, appelle **les mêmes
-      fonctions que le site**, et écrit `maquette/figures.js`
-      (`window.FIGURES = {histogramme: …, cartes: {id: …}}` via
-      `fig.to_json()`). Un `<script src>` local marche en `file://`, un
-      `fetch` non — d'où du JS et pas du JSON.
-- [ ] **[I]** `maquette/plotly.min.js` copié depuis le paquet Python
-      (`plotly/package_data/`). *Constat au passage* : `base.html` charge
+Pas de commande d'export séparée : **on part de la sortie de Django**, mais
+de ses fonctions Python plutôt que de son HTML. `maquette/construire.py`
+amorce Django, appelle `construire_vue_accueil()` puis les mêmes fonctions de
+figures que les vues, et écrit le tout en JS. Récupérer la page rendue par
+`runserver` aurait aussi marché, mais chaque figure y est un bloc de 1 Mo au
+milieu du gabarit, avec ses réglages figés dans l'appel `Plotly.newPlot` :
+impossible d'itérer sur la mise en page sans naviguer dans ces blocs, ni
+d'appliquer `charte.js` sans réanalyser le HTML. Séparer les données
+(générées) de la page (écrite à la main) est tout l'intérêt.
+
+- [x] **[I]** `graphiques.py` et `carte/API.py` exposent la **figure**
+      (`figure_histogramme`, `figure_carte`) ; `en_div` l'enrobe pour les
+      gabarits. Les vues n'ont pas changé.
+- [x] **[I]** `maquette/construire.py` écrit `maquette/figures.js`
+      (`window.VUE`, `window.FIGURES`) via `plotly.io.to_json`. Un
+      `<script src>` local marche en `file://`, un `fetch` non — d'où du JS et
+      pas du JSON. Non versionné (3,4 Mo pour trois cartes).
+- [x] **[I]** `maquette/plotly.min.js` copié depuis le paquet Python
+      (Plotly 6.9 → plotly.js 3). *Constat au passage* : `base.html` charge
       plotly.js **2.11 (2022) depuis le CDN** alors que le Python est en
-      Plotly 6, qui émet du plotly.js 3 — une figure jugée bonne en maquette
-      pourrait casser dans Django. Le vendorage prévu en « Hygiène » règle les
-      deux problèmes ; il remonte ici.
+      Plotly 6 — une figure jugée bonne en maquette pourrait casser dans
+      Django. Le vendorage prévu en « Hygiène » règle les deux problèmes ; il
+      remonte en 7.4.
+- [x] **[I]** `maquette/accueil.html`, variante 0 : le squelette qui prouve
+      la chaîne (héro, histogramme, trois cartes), vérifié dans Chromium via
+      `maquette/capture.mjs`. Les cartes Mapbox exigent WebGL et du vrai
+      temps : en headless, un rendu logiciel et quelques secondes d'attente.
 - [ ] **[I]** GeoJSON communal **simplifié** pour la maquette (1,6 Mo recopié
-      dans chaque carte → trois objets = 5 Mo de HTML). Un facteur 5 à 10 sur
-      les contours ne se voit pas à l'échelle du pays, et le site en profitera
-      aussi (la page d'accueil pèse aujourd'hui autant que le GeoJSON × objets).
+      dans chaque carte). Un facteur 5 à 10 sur les contours ne se voit pas à
+      l'échelle du pays, et le site en profitera aussi (la page d'accueil pèse
+      aujourd'hui autant que le GeoJSON × objets).
+- [ ] **[2]** Question ouverte par la vérification : `choropleth_mapbox` est
+      déprécié et exige WebGL, pour un fond `white-bg` qui n'apporte rien.
+      `px.choropleth` (projection SVG, `fitbounds="locations"`) rendrait la
+      même carte sans WebGL, imprimable et capturable partout. À trancher
+      pendant 7.2, en regardant les deux.
 
 #### 7.2 La maquette, et les itérations **[2]**
 
@@ -742,7 +756,7 @@ d'une variante par message.
       % extrapolé) et les figures de `figures.js`. **Deux ou trois variantes
       d'agencement** (`accueil-a.html`, `-b.html`…) plutôt qu'une seule :
       on compare, on ne devine pas.
-- [ ] **[I]** `maquette/charte.js` : **un seul bloc de réglages de design**
+- [x] **[I]** `maquette/charte.js` : **un seul bloc de réglages de design**
       (couleurs, échelle de carte ancrée à 50 %, marges, fonte, survol,
       modebar), appliqué **par-dessus** le JSON des figures au moment du
       `newPlot`. Changer l'apparence = changer une valeur ici et recharger ;

--- a/carte/API.py
+++ b/carte/API.py
@@ -1,12 +1,16 @@
 import statistics
 
 import geojson
-import plotly
 import plotly.express as px
 
+from scrutin.graphiques import en_div
 
-def generate_carte_plot(communes):
-    """``communes`` : le dict ``sujet["communes"]`` du contrat de vue."""
+
+def figure_carte(communes):
+    """``communes`` : le dict ``sujet["communes"]`` du contrat de vue.
+
+    Renvoie la figure Plotly ; ``generate_carte_plot`` l'enrobe en ``<div>``.
+    """
     with open("data/K4voge_20220501_gf.geojson") as f:
         gj = geojson.load(f)
     all_cities = []
@@ -30,24 +34,25 @@ def generate_carte_plot(communes):
     else:
         deciles = statistics.quantiles(valeurs_pour_couleur, n=10)
         lower_bound_color, upper_bound_color = deciles[0], deciles[-1]
-    div_containing_plot = plotly.offline.plot(px.choropleth_mapbox(dict_properties,
-                                                                   geojson=gj,
-                                                                   locations='name',
-                                                                   color='results',
-                                                                   center={"lat": 46.92, "lon": 8.22},
-                                                                   zoom=6,
-                                                                   # 20 is extremly zoomed... 10 still too much. 7 slightly too much
-                                                                   color_continuous_scale="RdYlGn",
-                                                                   featureidkey="properties.vogeName",
-                                                                   range_color=(lower_bound_color, upper_bound_color),
-                                                                   mapbox_style="white-bg",
-                                                                   opacity=0.5,
-                                                                   labels={'results_formated': 'Resultat',
-                                                                           'name': 'Nom'},
-                                                                   hover_data={'name': True, 'results_formated': True,
-                                                                               'results': False}
-                                                                   ),
-                                              include_plotlyjs=False,
-                                              output_type='div')
-    return div_containing_plot
+    return px.choropleth_mapbox(dict_properties,
+                               geojson=gj,
+                               locations='name',
+                               color='results',
+                               center={"lat": 46.92, "lon": 8.22},
+                               zoom=6,
+                               # 20 is extremly zoomed... 10 still too much. 7 slightly too much
+                               color_continuous_scale="RdYlGn",
+                               featureidkey="properties.vogeName",
+                               range_color=(lower_bound_color, upper_bound_color),
+                               mapbox_style="white-bg",
+                               opacity=0.5,
+                               labels={'results_formated': 'Resultat',
+                                       'name': 'Nom'},
+                               hover_data={'name': True, 'results_formated': True,
+                                           'results': False}
+                               )
+
+
+def generate_carte_plot(communes):
+    return en_div(figure_carte(communes))
 

--- a/maquette/README.md
+++ b/maquette/README.md
@@ -1,0 +1,28 @@
+# Maquette statique de l'accueil
+
+Le laboratoire de design de la voie Interface (`PLAN_MODERNISATION.md`,
+Partie 7). Une page HTML qu'on ouvre en `file://`, avec les **vraies figures
+Plotly** du site embarquées en JSON — interactives et éditables, là où un PNG
+figerait ce qu'on veut faire varier.
+
+```bash
+python manage.py peupler_demo        # base fictive, une fois
+python maquette/construire.py        # écrit figures.js, copie plotly.min.js
+xdg-open maquette/accueil.html       # ou double-clic
+```
+
+| Fichier | Rôle | Versionné |
+|---|---|---|
+| `construire.py` | génère les fichiers ci-dessous depuis la base fictive, avec les fonctions du site | oui |
+| `figures.js` | contrat de vue + figures en JSON (`window.VUE`, `window.FIGURES`) | **non** (généré, ~5 Mo) |
+| `plotly.min.js` | plotly.js, copié du paquet Python — la version qui a produit les figures | **non** (généré) |
+| `charte.js` | **les réglages de design**, appliqués par-dessus les figures au chargement | oui |
+| `accueil.html` | variante 0, le squelette ; les variantes d'agencement s'appellent `accueil-a.html`, `-b.html`… | oui |
+| `capture.mjs` | capture PNG d'une variante (Playwright), pour discuter par message | oui |
+
+Pour changer l'apparence d'un graphe, on édite `charte.js` et on recharge.
+On n'édite jamais `figures.js` : il sort de `graphiques.py` et `carte/`, comme
+les figures du site, et c'est ce qui garantit que la maquette ne promet rien
+que Django ne donnerait pas.
+
+Largeur téléphone : `node maquette/capture.mjs maquette/accueil.html tel.png 400`.

--- a/maquette/accueil.html
+++ b/maquette/accueil.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Politiques.ch — maquette de l'accueil (variante 0, squelette)</title>
+<style>
+  /* Variante 0 : le squelette qui prouve la chaîne construire.py → figures.js
+     → page. Les variantes d'agencement (accueil-a.html, -b.html) partent d'ici. */
+  :root {
+    --surface: #fcfcfb; --encre-1: #1f1f1c; --encre-2: #5f5e58;
+    --grille: #e1e0d9; --bleu: #2a78d6; --bleu-clair: #86b6ef; --rouge: #c9352b;
+  }
+  html { background: var(--surface); color: var(--encre-1);
+         font: 16px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+  body { margin: 0; padding: 0 16px 48px; max-width: 1100px; margin-inline: auto; }
+  header { display: flex; align-items: baseline; gap: 16px; padding: 16px 0; border-bottom: 1px solid var(--grille); }
+  header h1 { font-size: 1.25rem; margin: 0; color: var(--bleu); }
+  header nav a { color: var(--encre-2); text-decoration: none; margin-left: 16px; }
+  h2 { font-size: 1.1rem; font-weight: 600; margin: 32px 0 8px; }
+  .sous { color: var(--encre-2); margin: 0 0 16px; }
+  .heros { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 16px; margin-top: 24px; }
+  .hero { border: 1px solid var(--grille); border-radius: 8px; padding: 16px; }
+  .hero .nom { color: var(--encre-2); font-size: .95rem; min-height: 3em; }
+  .hero .chiffre { font-size: 2.6rem; font-weight: 700; line-height: 1.1; letter-spacing: -.02em; }
+  .hero .oui { color: var(--bleu); } .hero .non { color: var(--rouge); }
+  .hero .verdict { font-weight: 600; } .hero .connu { color: var(--encre-2); font-size: .9rem; }
+  .figure { border: 1px solid var(--grille); border-radius: 8px; overflow: hidden; }
+  .cartes { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; }
+  footer { color: var(--encre-2); font-size: .85rem; margin-top: 48px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Politiques.ch</h1>
+  <nav><a href="#">Accueil</a><a href="#">Cartes</a><a href="#">Méthodes</a><a href="#">Contact</a></nav>
+</header>
+
+<h2 id="titre"></h2>
+<p class="sous" id="avance"></p>
+<section class="heros" id="heros"></section>
+
+<h2>Pourcentage de oui, dépouillé et projeté</h2>
+<div class="figure" id="histogramme"></div>
+
+<h2>Par commune</h2>
+<p class="sous">Bleu : penche oui. Rouge : penche non. Gris : autour de 50 %.</p>
+<section class="cartes" id="cartes"></section>
+
+<footer>Maquette statique — données fictives (<code>peupler_demo</code>). Figures produites par le code du site.</footer>
+
+<script src="plotly.min.js"></script>
+<script src="charte.js"></script>
+<script src="figures.js"></script>
+<script>
+  const vue = window.VUE, figures = window.FIGURES;
+  const pct = (v) => (100 * v).toLocaleString("fr-CH", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + " %";
+  const date = new Date(vue.date).toLocaleDateString("fr-CH", { day: "numeric", month: "long", year: "numeric" });
+
+  document.getElementById("titre").textContent = "Votation fédérale du " + date;
+  document.getElementById("avance").textContent = "Projection basée sur " + pct(vue.avance) + " du dépouillement.";
+
+  const heros = document.getElementById("heros");
+  for (const s of vue.sujets) {
+    const oui = s.oui_extrapole >= 0.5;
+    const el = document.createElement("article");
+    el.className = "hero";
+    el.innerHTML = `<div class="nom">${s.nom}</div>
+      <div class="chiffre ${oui ? "oui" : "non"}">${pct(s.oui_extrapole)}</div>
+      <div class="verdict">${oui ? "Accepté" : "Refusé"} <span class="connu">(projeté)</span></div>
+      <div class="connu">Dépouillé à ce stade : ${pct(s.oui_connu)} de oui</div>`;
+    heros.appendChild(el);
+  }
+
+  const h = window.appliquerCharte(figures.histogramme, "histogramme");
+  Plotly.newPlot("histogramme", h.data, h.layout, window.CONFIG_PLOTLY);
+
+  const cartes = document.getElementById("cartes");
+  for (const s of vue.sujets) {
+    const bloc = document.createElement("div");
+    bloc.innerHTML = `<h3 style="font-size:1rem;margin:0 0 8px">${s.nom}</h3><div class="figure"></div>`;
+    cartes.appendChild(bloc);
+    const c = window.appliquerCharte(figures.cartes[s.id], "carte");
+    Plotly.newPlot(bloc.querySelector(".figure"), c.data, c.layout, window.CONFIG_PLOTLY);
+  }
+</script>
+</body>
+</html>

--- a/maquette/capture.mjs
+++ b/maquette/capture.mjs
@@ -1,0 +1,23 @@
+// Capture d'écran d'une variante, pour en discuter par message (le PNG n'est
+// jamais le support de travail : la page l'est).
+//
+//     node maquette/capture.mjs maquette/accueil.html accueil.png [largeur]
+//
+// Demande Playwright (npm i -g playwright, ou npx). Les cartes Mapbox ont
+// besoin de WebGL et de vrai temps : on attend quelques secondes après le
+// chargement, et on lance Chromium avec un rendu logiciel si besoin.
+import { chromium } from "playwright";
+import { resolve } from "node:path";
+
+const [, , page_html = "maquette/accueil.html", sortie = "accueil.png", largeur = "1200"] = process.argv;
+const navigateur = await chromium.launch({
+  executablePath: process.env.CHROME || undefined,
+  args: ["--use-gl=angle", "--use-angle=swiftshader", "--enable-unsafe-swiftshader", "--ignore-gpu-blocklist"],
+});
+const page = await navigateur.newPage({ viewport: { width: Number(largeur), height: 1200 } });
+page.on("pageerror", (e) => console.error("Erreur JS :", String(e).slice(0, 200)));
+await page.goto("file://" + resolve(page_html), { waitUntil: "load" });
+await page.waitForTimeout(8000);
+await page.screenshot({ path: sortie, fullPage: true });
+await navigateur.close();
+console.log(sortie);

--- a/maquette/charte.js
+++ b/maquette/charte.js
@@ -1,0 +1,88 @@
+// Réglages de design de la maquette : le brouillon de scrutin/charte.py.
+// On change une valeur ici, on recharge la page. On ne touche jamais aux
+// données des figures (figures.js est généré).
+//
+// Palette : celle validée dans PLAN_MODERNISATION.md Partie 7
+// (validate_palette.js, surface #fcfcfb).
+window.CHARTE = {
+  surface: "#fcfcfb",
+  encre1: "#1f1f1c",
+  encre2: "#5f5e58",
+  grille: "#e1e0d9",
+  bleu: "#2a78d6",       // confirmé
+  bleuClair: "#86b6ef",  // extrapolé (même teinte, plus clair = estimé)
+  orange: "#eb6834",     // alternative validée pour « extrapolé »
+  gris: "#f0efec",       // milieu neutre de l'échelle de carte
+  rouge: "#c9352b",      // « penche non »
+  fonte: "system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+  carte: {
+    // Divergente ancrée à 50 % : non ← gris neutre → oui, bornes symétriques.
+    demiEtendue: 20,     // 30 % … 70 %
+    opacite: 0.95,
+    hauteur: 420,
+  },
+  histogramme: {
+    hauteur: 360,
+  },
+};
+
+// Options passées à Plotly.newPlot : pas de barre d'outils, largeur fluide.
+window.CONFIG_PLOTLY = { displayModeBar: false, responsive: true, displaylogo: false };
+
+// Applique la charte par-dessus une figure exportée par construire.py.
+// `genre` vaut "histogramme" ou "carte". Renvoie {data, layout}.
+window.appliquerCharte = function (fig, genre) {
+  const c = window.CHARTE;
+  const data = JSON.parse(JSON.stringify(fig.data));
+  const layout = JSON.parse(JSON.stringify(fig.layout));
+
+  layout.font = { family: c.fonte, color: c.encre1, size: 14 };
+  layout.paper_bgcolor = c.surface;
+  layout.plot_bgcolor = c.surface;
+  layout.margin = { l: 8, r: 8, t: 8, b: 8 };
+
+  if (genre === "histogramme") {
+    // Deux traces : « Déja dépouillés » puis « Extrapolés » (même teinte, plus clair).
+    const couleurs = [c.bleu, c.bleuClair];
+    data.forEach((trace, i) => {
+      trace.marker = Object.assign({}, trace.marker, { color: couleurs[i] });
+      trace.textposition = "outside";
+      trace.textfont = { color: c.encre2 };
+    });
+    layout.height = c.histogramme.hauteur;
+    layout.margin = { l: 48, r: 8, t: 16, b: 40 };
+    layout.legend = { orientation: "h", y: -0.18, title: { text: "" } };
+    layout.xaxis = Object.assign({}, layout.xaxis, { title: { text: "" }, showgrid: false });
+    layout.yaxis = Object.assign({}, layout.yaxis, {
+      title: { text: "" }, tickformat: ".0%", gridcolor: c.grille, zeroline: false, range: [0, 1],
+    });
+    // La ligne de majorité : l'information n°1 d'une votation.
+    layout.shapes = [{
+      type: "line", xref: "paper", x0: 0, x1: 1, y0: 0.5, y1: 0.5,
+      line: { color: c.encre2, width: 1, dash: "dot" },
+    }];
+    layout.annotations = [{
+      xref: "paper", x: 1, y: 0.5, xanchor: "right", yanchor: "bottom",
+      text: "majorité", showarrow: false, font: { size: 12, color: c.encre2 },
+    }];
+  }
+
+  if (genre === "carte") {
+    const d = c.carte.demiEtendue;
+    layout.coloraxis = Object.assign({}, layout.coloraxis, {
+      colorscale: [[0, c.rouge], [0.5, c.gris], [1, c.bleu]],
+      cmin: 50 - d, cmid: 50, cmax: 50 + d,
+      colorbar: {
+        title: { text: "% oui" }, ticksuffix: " %", thickness: 10, len: 0.6,
+        outlinewidth: 0, tickfont: { color: c.encre2 },
+      },
+    });
+    data.forEach((trace) => {
+      trace.marker = Object.assign({}, trace.marker, { opacity: c.carte.opacite, line: { width: 0.2, color: c.surface } });
+    });
+    layout.height = c.carte.hauteur;
+    layout.margin = { l: 0, r: 0, t: 0, b: 0 };
+  }
+
+  return { data, layout };
+};

--- a/maquette/construire.py
+++ b/maquette/construire.py
@@ -1,0 +1,71 @@
+"""Fabrique les données de la maquette statique depuis la base fictive.
+
+    python manage.py peupler_demo      # une fois
+    python maquette/construire.py      # puis ouvrir maquette/accueil.html
+
+Écrit ``figures.js`` (le contrat de vue et les figures Plotly en JSON) et
+copie ``plotly.min.js`` depuis le paquet Python — la même version que celle
+qui produit les figures. Les deux fichiers sont générés, jamais édités à la
+main, et ne sont pas versionnés.
+
+Les figures sortent **des mêmes fonctions que le site** (``figure_histogramme``,
+``figure_carte``) : la maquette ne peut pas promettre un rendu que Django ne
+donnerait pas. Ce que la maquette ajoute par-dessus vit dans ``charte.js``.
+
+Un ``<script src>`` local fonctionne en ``file://``, un ``fetch`` non : c'est
+pourquoi on écrit du JS (``window.FIGURES = …``) et pas du JSON.
+"""
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+ICI = Path(__file__).resolve().parent
+RACINE = ICI.parent
+sys.path.insert(0, str(RACINE))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "election.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+import plotly  # noqa: E402
+import plotly.io as pio  # noqa: E402
+
+from carte.API import figure_carte  # noqa: E402
+from scrutin.donnees import construire_vue_accueil  # noqa: E402
+from scrutin.graphiques import figure_histogramme  # noqa: E402
+
+
+def main():
+    vue = construire_vue_accueil()
+
+    # Le contrat sans les résultats par commune : ils sont déjà dans les cartes.
+    vue_legere = {
+        "date": vue["date"],
+        "avance": vue["avance"],
+        "sujets": [{k: v for k, v in sujet.items() if k != "communes"} for sujet in vue["sujets"]],
+    }
+
+    morceaux = ["// Généré par maquette/construire.py — ne pas éditer.\n"]
+    morceaux.append(f"window.VUE = {pio.json.to_json_plotly(vue_legere)};\n")
+    morceaux.append("window.FIGURES = {\n")
+    morceaux.append(f"  histogramme: {pio.to_json(figure_histogramme(vue))},\n")
+    morceaux.append("  cartes: {\n")
+    for sujet in vue["sujets"]:
+        morceaux.append(f"    {sujet['id']}: {pio.to_json(figure_carte(sujet['communes']))},\n")
+    morceaux.append("  },\n};\n")
+    sortie = ICI / "figures.js"
+    sortie.write_text("".join(morceaux), encoding="utf-8")
+
+    source_js = Path(plotly.__file__).parent / "package_data" / "plotly.min.js"
+    shutil.copyfile(source_js, ICI / "plotly.min.js")
+
+    print(f"{sortie.name} : {sortie.stat().st_size / 1e6:.1f} Mo "
+          f"({len(vue['sujets'])} cartes), plotly.min.js : "
+          f"{source_js.stat().st_size / 1e6:.1f} Mo (Plotly {plotly.__version__})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scrutin/graphiques.py
+++ b/scrutin/graphiques.py
@@ -2,10 +2,20 @@
 
 Ces fonctions ne consomment que le contrat de vue construit par
 `scrutin.donnees` : aucun accès à l'ORM ici.
+
+Chaque figure existe sous deux formes : ``figure_*`` renvoie l'objet Plotly
+(ce que la maquette statique exporte en JSON, voir ``maquette/``), et la
+fonction sans préfixe l'enrobe en ``<div>`` pour les gabarits Django. Les deux
+partagent le même code : la maquette et le site ne peuvent pas diverger.
 """
 
 import plotly
 import plotly.express as px
+
+
+def en_div(figure):
+    """Le ``<div>`` autonome qu'attendent les gabarits (sans plotly.js)."""
+    return plotly.offline.plot(figure, include_plotlyjs=False, output_type='div')
 
 
 def clean_name(name):
@@ -14,7 +24,7 @@ def clean_name(name):
         return "AVS-TVA"
 
 
-def histogramme(vue):
+def figure_histogramme(vue):
     noms = [clean_name(sujet["nom"]) for sujet in vue["sujets"]]
     connus = [sujet["oui_connu"] for sujet in vue["sujets"]]
     extrapoles = [sujet["oui_extrapole"] for sujet in vue["sujets"]]
@@ -24,12 +34,14 @@ def histogramme(vue):
         "value": connus + extrapoles,
     }
     ddf["formated_value"] = [f"{100*v:.1f}%" for v in ddf["value"]]
-    return plotly.offline.plot(px.bar(ddf, x="sujet",
-                                      y='value',
-                                      color="pourcentage de oui",
-                                      barmode="group",
-                                      title="",
-                                      hover_name="sujet",
-                                      text="formated_value"),
-                               include_plotlyjs=False,
-                               output_type='div')
+    return px.bar(ddf, x="sujet",
+                  y='value',
+                  color="pourcentage de oui",
+                  barmode="group",
+                  title="",
+                  hover_name="sujet",
+                  text="formated_value")
+
+
+def histogramme(vue):
+    return en_div(figure_histogramme(vue))


### PR DESCRIPTION
Empilée sur #41 (le plan) — à relire après lui, ou à fusionner ensemble.

Met en place la chaîne qui régénère la maquette depuis la base fictive.

## On part de la sortie de Django, mais de ses fonctions Python

Pas de commande d'export séparée. `maquette/construire.py` amorce Django, appelle `construire_vue_accueil()` puis **les mêmes fonctions de figures que les vues**, et écrit le tout en JS.

Récupérer la page rendue par `runserver` aurait marché aussi, mais chaque figure y est un bloc de 1 Mo au milieu du gabarit, avec ses réglages figés dans l'appel `Plotly.newPlot` : impossible d'itérer sur la mise en page sans naviguer dans ces blocs, ni d'appliquer un jeu de réglages par-dessus sans réanalyser le HTML. Séparer les données (générées) de la page (écrite à la main) est tout l'intérêt.

## Le refactor, minimal

`graphiques.py` et `carte/API.py` exposent désormais la **figure** (`figure_histogramme`, `figure_carte`) ; `en_div` l'enrobe pour les gabarits. **Les vues sont inchangées** et le site rend exactement la même chose.

## Le dossier

| Fichier | Rôle | Versionné |
|---|---|---|
| `construire.py` | génère les fichiers ci-dessous, avec les fonctions du site | oui |
| `figures.js` | contrat de vue + figures en JSON | non (généré, 3,4 Mo) |
| `plotly.min.js` | copié du paquet Python — la version qui a produit les figures | non (généré) |
| `charte.js` | les réglages de design, appliqués au chargement | oui |
| `accueil.html` | variante 0, le squelette qui prouve la chaîne | oui |
| `capture.mjs` | capture PNG via Playwright, pour discuter par message | oui |

Un `<script src>` local fonctionne en `file://`, un `fetch` non : d'où du JS et pas du JSON.

Pour changer l'apparence d'un graphe, on édite `charte.js` et on recharge. On n'édite jamais `figures.js` : il sort de `graphiques.py` et `carte/`, comme les figures du site, et c'est ce qui garantit que la maquette ne promet rien que Django ne donnerait pas.

## Deux constats remontés dans le plan

- **Décalage de version Plotly** : `base.html` charge plotly.js **2.11 (2022) depuis le CDN** alors que le Python est en Plotly 6, qui émet du plotly.js 3. Une figure jugée bonne en maquette pourrait casser dans Django. La maquette vendore la bonne version ; le site suivra en 7.4.
- **`choropleth_mapbox` est déprécié et exige WebGL**, pour un fond `white-bg` qui n'apporte rien. `px.choropleth` (projection SVG) rendrait la même carte sans WebGL, imprimable et capturable partout. À trancher pendant 7.2, en regardant les deux.

## Vérifications

`ruff check .` et les 55 tests passent. La page a été rendue dans Chromium en 1200 px et en 400 px : chiffre héro par objet, histogramme avec la ligne de majorité, trois cartes interactives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RinRFrnqgn8D8D77URP1Nn

---
_Generated by [Claude Code](https://claude.ai/code/session_01RinRFrnqgn8D8D77URP1Nn)_